### PR TITLE
Add a constructor that let the user to use a custom Ignite instance

### DIFF
--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -4,6 +4,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.ignite.IgniteClusterManager;
+
+import org.apache.ignite.Ignite;
 import org.apache.ignite.configuration.IgniteConfiguration;
 
 /**
@@ -40,4 +42,19 @@ public class Examples {
     });
   }
 
+  public void example3() {
+    //Creation code (ommited)
+    Ignite ignite = null;
+    ClusterManager clusterManager = new IgniteClusterManager(ignite);
+
+    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    Vertx.clusteredVertx(options, res -> {
+      if (res.succeeded()) {
+        Vertx vertx = res.result();
+      } else {
+        // failed!
+      }
+    });
+  }
+  
 }


### PR DESCRIPTION
Creates cluster manager instance with given Ignite instance. Use this constructor in order to share ignite cluster created outside IgniteClusterManager. Do not shutdown the cluster if we are not the owner of the cluster.