### PR TITLE
Make dependency on Spring optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,26 +42,6 @@
       <version>${ignite.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.ignite</groupId>
-      <artifactId>ignite-spring</artifactId>
-      <version>${ignite.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-aop</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-tx</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-jdbc</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
       <scope>provided</scope>

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -72,17 +72,119 @@ Vertx.clusteredVertx(options, res -> {
 
 == Configuring cluster manager
 
-=== Using configuration file
+=== Using JSON configuration file
 
-The cluster manager is configured by a file `default-ignite.xml` which is packaged inside the jar.
+The cluster manager is configured by a file `default-ignite.json` which is packaged inside the jar.
 
-If you want to override this configuration you can provide `ignite.xml` file on your classpath and this will be
+If you want to override this configuration you can provide `ignite.json` file on your classpath and this will be
 used instead.
 
-The xml file is a Ignite configuration file and is described in details in
+JSON configuration file represent *org.apache.ignite.configuration.IgniteConfiguration* class.
+Refer https://ignite.apache.org/releases/mobile/org/apache/ignite/configuration/IgniteConfiguration.html[Javadoc] for details.
+Please use @class meta property for specify type of inner classes, like DiscoverySpi, TcpDiscoveryIpFinder and so.
+You can use both integer numbers and named constants from *org.apache.ignite.events.EventType* class for includeEventTypes property.
+
+Example:
+[source,json]
+----
+{
+	"localHost" : "127.0.0.1",
+	"discoverySpi" : {
+		"@class" : "org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi",
+		"ipFinder" : {
+			"@class" : "org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder",
+			"addresses" : ["127.0.0.1:47500..47549"]
+		}
+	},
+	"cacheConfiguration" : [{
+		"name" : "*",
+		"cacheMode" : "PARTITIONED",
+        "backups" : 1,
+        "readFromBackup" : false,
+        "startSize" : 15000,
+        "affinity" : {
+        	"@class" : "org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction",
+        	"partitions" : 128
+        }
+	}],
+	"includeEventTypes" : [
+		"EVT_CACHE_OBJECT_REMOVED"
+	],
+	"metricsLogFrequency" : 0
+}
+----
+
+=== Using XML configuration file
+
+To configure Ignite using XML configuration file, you must add ignite-spring dependency to classpath:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+ <dependency>
+  <groupId>org.apache.ignite</groupId>
+  <artifactId>ignite-spring</artifactId>
+  <version>3.4.1</version>
+  <exclusions>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </exclusion>
+  </exclusions>
+ </dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'org.apache.ignite:ignite-spring:3.4.1' {
+	exclude group: 'org.springframework', module: 'spring-aop'
+	exclude group: 'org.springframework', module: 'spring-tx'
+	exclude group: 'org.springframework', module: 'spring-jdbc'
+}
+----
+
+If you want to override default `default-ignite.json` configuration you can provide `ignite.xml` file on your classpath and this will be
+used instead.
+
+The xml file is than a Ignite configuration file and is described in details in
 https://apacheignite.readme.io/docs[Apache Ignite documentation].
 
-### Configuring programmatically
+----
+ClusterManager clusterManager = new IgniteClusterManager("ignite.xml");
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+----
+
+=== Specify configuration file programmatically
+
+You can also specify configuration file programmatically:
+
+[source,java]
+----
+URL url = json or xml configuration URL construction code (omitted)
+ClusterManager clusterManager = new IgniteClusterManager(url);
+
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+Vertx.clusteredVertx(options, res -> {
+  if (res.succeeded()) {
+    Vertx vertx = res.result();
+  } else {
+    // failed!
+  }
+});
+----
+
+=== Configuring programmatically
 
 You can also specify configuration programmatically:
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -72,17 +72,119 @@ Vertx.clusteredVertx(options, res -> {
 
 == Configuring cluster manager
 
-=== Using configuration file
+=== Using JSON configuration file
 
-The cluster manager is configured by a file `default-ignite.xml` which is packaged inside the jar.
+The cluster manager is configured by a file `default-ignite.json` which is packaged inside the jar.
 
-If you want to override this configuration you can provide `ignite.xml` file on your classpath and this will be
+If you want to override this configuration you can provide `ignite.json` file on your classpath and this will be
 used instead.
 
-The xml file is a Ignite configuration file and is described in details in
+JSON configuration file represent *org.apache.ignite.configuration.IgniteConfiguration* class.
+Refer https://ignite.apache.org/releases/mobile/org/apache/ignite/configuration/IgniteConfiguration.html[Javadoc] for details.
+Please use @class meta property for specify type of inner classes, like DiscoverySpi, TcpDiscoveryIpFinder and so.
+You can use both integer numbers and named constants from *org.apache.ignite.events.EventType* class for includeEventTypes property.
+
+Example:
+[source,json]
+----
+{
+	"localHost" : "127.0.0.1",
+	"discoverySpi" : {
+		"@class" : "org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi",
+		"ipFinder" : {
+			"@class" : "org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder",
+			"addresses" : ["127.0.0.1:47500..47549"]
+		}
+	},
+	"cacheConfiguration" : [{
+		"name" : "*",
+		"cacheMode" : "PARTITIONED",
+        "backups" : 1,
+        "readFromBackup" : false,
+        "startSize" : 15000,
+        "affinity" : {
+        	"@class" : "org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction",
+        	"partitions" : 128
+        }
+	}],
+	"includeEventTypes" : [
+		"EVT_CACHE_OBJECT_REMOVED"
+	],
+	"metricsLogFrequency" : 0
+}
+----
+
+=== Using XML configuration file
+
+To configure Ignite using XML configuration file, you must add ignite-spring dependency to classpath:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+ <dependency>
+  <groupId>org.apache.ignite</groupId>
+  <artifactId>ignite-spring</artifactId>
+  <version>3.4.1</version>
+  <exclusions>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </exclusion>
+  </exclusions>
+ </dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'org.apache.ignite:ignite-spring:3.4.1' {
+	exclude group: 'org.springframework', module: 'spring-aop'
+	exclude group: 'org.springframework', module: 'spring-tx'
+	exclude group: 'org.springframework', module: 'spring-jdbc'
+}
+----
+
+If you want to override default `default-ignite.json` configuration you can provide `ignite.xml` file on your classpath and this will be
+used instead.
+
+The xml file is than a Ignite configuration file and is described in details in
 https://apacheignite.readme.io/docs[Apache Ignite documentation].
 
-### Configuring programmatically
+----
+ClusterManager clusterManager = new IgniteClusterManager("ignite.xml");
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+----
+
+=== Specify configuration file programmatically
+
+You can also specify configuration file programmatically:
+
+[source,java]
+----
+URL url = json or xml configuration URL construction code (omitted)
+ClusterManager clusterManager = new IgniteClusterManager(url);
+
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+Vertx.clusteredVertx(options, res -> {
+  if (res.succeeded()) {
+    Vertx vertx = res.result();
+  } else {
+    // failed!
+  }
+});
+----
+
+=== Configuring programmatically
 
 You can also specify configuration programmatically:
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -72,17 +72,119 @@ Vertx.clusteredVertx(options, res -> {
 
 == Configuring cluster manager
 
-=== Using configuration file
+=== Using JSON configuration file
 
-The cluster manager is configured by a file `default-ignite.xml` which is packaged inside the jar.
+The cluster manager is configured by a file `default-ignite.json` which is packaged inside the jar.
 
-If you want to override this configuration you can provide `ignite.xml` file on your classpath and this will be
+If you want to override this configuration you can provide `ignite.json` file on your classpath and this will be
 used instead.
 
-The xml file is a Ignite configuration file and is described in details in
+JSON configuration file represent *org.apache.ignite.configuration.IgniteConfiguration* class.
+Refer https://ignite.apache.org/releases/mobile/org/apache/ignite/configuration/IgniteConfiguration.html[Javadoc] for details.
+Please use @class meta property for specify type of inner classes, like DiscoverySpi, TcpDiscoveryIpFinder and so.
+You can use both integer numbers and named constants from *org.apache.ignite.events.EventType* class for includeEventTypes property.
+
+Example:
+[source,json]
+----
+{
+	"localHost" : "127.0.0.1",
+	"discoverySpi" : {
+		"@class" : "org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi",
+		"ipFinder" : {
+			"@class" : "org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder",
+			"addresses" : ["127.0.0.1:47500..47549"]
+		}
+	},
+	"cacheConfiguration" : [{
+		"name" : "*",
+		"cacheMode" : "PARTITIONED",
+        "backups" : 1,
+        "readFromBackup" : false,
+        "startSize" : 15000,
+        "affinity" : {
+        	"@class" : "org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction",
+        	"partitions" : 128
+        }
+	}],
+	"includeEventTypes" : [
+		"EVT_CACHE_OBJECT_REMOVED"
+	],
+	"metricsLogFrequency" : 0
+}
+----
+
+=== Using XML configuration file
+
+To configure Ignite using XML configuration file, you must add ignite-spring dependency to classpath:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+ <dependency>
+  <groupId>org.apache.ignite</groupId>
+  <artifactId>ignite-spring</artifactId>
+  <version>3.4.1</version>
+  <exclusions>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </exclusion>
+  </exclusions>
+ </dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'org.apache.ignite:ignite-spring:3.4.1' {
+	exclude group: 'org.springframework', module: 'spring-aop'
+	exclude group: 'org.springframework', module: 'spring-tx'
+	exclude group: 'org.springframework', module: 'spring-jdbc'
+}
+----
+
+If you want to override default `default-ignite.json` configuration you can provide `ignite.xml` file on your classpath and this will be
+used instead.
+
+The xml file is than a Ignite configuration file and is described in details in
 https://apacheignite.readme.io/docs[Apache Ignite documentation].
 
-### Configuring programmatically
+----
+ClusterManager clusterManager = new IgniteClusterManager("ignite.xml");
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+----
+
+=== Specify configuration file programmatically
+
+You can also specify configuration file programmatically:
+
+[source,java]
+----
+URL url = json or xml configuration URL construction code (omitted)
+ClusterManager clusterManager = new IgniteClusterManager(url);
+
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+Vertx.clusteredVertx(options, res -> {
+  if (res.succeeded()) {
+    Vertx vertx = res.result();
+  } else {
+    // failed!
+  }
+});
+----
+
+=== Configuring programmatically
 
 You can also specify configuration programmatically:
 

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -72,17 +72,119 @@ Vertx.clusteredVertx(options, res -> {
 
 == Configuring cluster manager
 
-=== Using configuration file
+=== Using JSON configuration file
 
-The cluster manager is configured by a file `default-ignite.xml` which is packaged inside the jar.
+The cluster manager is configured by a file `default-ignite.json` which is packaged inside the jar.
 
-If you want to override this configuration you can provide `ignite.xml` file on your classpath and this will be
+If you want to override this configuration you can provide `ignite.json` file on your classpath and this will be
 used instead.
 
-The xml file is a Ignite configuration file and is described in details in
+JSON configuration file represent *org.apache.ignite.configuration.IgniteConfiguration* class.
+Refer https://ignite.apache.org/releases/mobile/org/apache/ignite/configuration/IgniteConfiguration.html[Javadoc] for details.
+Please use @class meta property for specify type of inner classes, like DiscoverySpi, TcpDiscoveryIpFinder and so.
+You can use both integer numbers and named constants from *org.apache.ignite.events.EventType* class for includeEventTypes property.
+
+Example:
+[source,json]
+----
+{
+	"localHost" : "127.0.0.1",
+	"discoverySpi" : {
+		"@class" : "org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi",
+		"ipFinder" : {
+			"@class" : "org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder",
+			"addresses" : ["127.0.0.1:47500..47549"]
+		}
+	},
+	"cacheConfiguration" : [{
+		"name" : "*",
+		"cacheMode" : "PARTITIONED",
+        "backups" : 1,
+        "readFromBackup" : false,
+        "startSize" : 15000,
+        "affinity" : {
+        	"@class" : "org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction",
+        	"partitions" : 128
+        }
+	}],
+	"includeEventTypes" : [
+		"EVT_CACHE_OBJECT_REMOVED"
+	],
+	"metricsLogFrequency" : 0
+}
+----
+
+=== Using XML configuration file
+
+To configure Ignite using XML configuration file, you must add ignite-spring dependency to classpath:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+ <dependency>
+  <groupId>org.apache.ignite</groupId>
+  <artifactId>ignite-spring</artifactId>
+  <version>3.4.1</version>
+  <exclusions>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </exclusion>
+  </exclusions>
+ </dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'org.apache.ignite:ignite-spring:3.4.1' {
+	exclude group: 'org.springframework', module: 'spring-aop'
+	exclude group: 'org.springframework', module: 'spring-tx'
+	exclude group: 'org.springframework', module: 'spring-jdbc'
+}
+----
+
+If you want to override default `default-ignite.json` configuration you can provide `ignite.xml` file on your classpath and this will be
+used instead.
+
+The xml file is than a Ignite configuration file and is described in details in
 https://apacheignite.readme.io/docs[Apache Ignite documentation].
 
-### Configuring programmatically
+----
+ClusterManager clusterManager = new IgniteClusterManager("ignite.xml");
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+----
+
+=== Specify configuration file programmatically
+
+You can also specify configuration file programmatically:
+
+[source,java]
+----
+URL url = json or xml configuration URL construction code (omitted)
+ClusterManager clusterManager = new IgniteClusterManager(url);
+
+VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+Vertx.clusteredVertx(options, res -> {
+  if (res.succeeded()) {
+    Vertx vertx = res.result();
+  } else {
+    // failed!
+  }
+});
+----
+
+=== Configuring programmatically
 
 You can also specify configuration programmatically:
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/cfg/EventTypeConverter.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/cfg/EventTypeConverter.java
@@ -1,0 +1,36 @@
+package io.vertx.spi.cluster.ignite.cfg;
+
+import java.lang.reflect.Field;
+
+import org.apache.ignite.events.EventType;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+
+public class EventTypeConverter extends StdConverter<Object[],int[]> {
+
+  @Override
+  public int[] convert(Object[] value) {
+    if(value == null)
+      return null;
+    else {
+      int[] result = new int[value.length];
+      for (int i = 0; i < value.length; i++) {
+        Object object = value[i];
+        if(object instanceof Number) {
+          result[i] = ((Number) object).intValue();
+        } else if(object instanceof String) {
+          try {
+            Field declaredField = EventType.class.getDeclaredField(((String) object).toUpperCase());
+            result[i] = (int) declaredField.get(EventType.class);
+          } catch (Exception e) {
+            throw new IllegalArgumentException("Illegal value "+object+" for IncludeEventTypes, event must be int or constant from EventType class");
+          }
+        } else {
+          throw new IllegalArgumentException("Illegal value "+object+" for IncludeEventTypes, event must be int or constant from EventType class");
+        }
+      }
+      return result;
+    }    
+  }
+
+}

--- a/src/main/java/io/vertx/spi/cluster/ignite/cfg/IgniteConfigurationLoader.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/cfg/IgniteConfigurationLoader.java
@@ -1,0 +1,15 @@
+package io.vertx.spi.cluster.ignite.cfg;
+
+import java.io.InputStream;
+
+import org.apache.ignite.configuration.IgniteConfiguration;
+
+import io.vertx.core.json.JsonObject;
+
+public interface IgniteConfigurationLoader {
+
+  IgniteConfiguration fromJson(JsonObject json);
+  IgniteConfiguration fromJson(String json);
+  IgniteConfiguration fromJson(InputStream is);
+  
+}

--- a/src/main/java/io/vertx/spi/cluster/ignite/cfg/IgniteConfigurationMixin.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/cfg/IgniteConfigurationMixin.java
@@ -1,0 +1,25 @@
+package io.vertx.spi.cluster.ignite.cfg;
+
+import java.util.Map;
+
+import javax.management.MBeanServer;
+
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.events.Event;
+import org.apache.ignite.lang.IgnitePredicate;
+import org.apache.ignite.lifecycle.LifecycleBean;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+public interface IgniteConfigurationMixin {
+
+  @JsonIgnore Map<IgnitePredicate<? extends Event>, int[]> getLocalEventListeners();
+  @JsonIgnore MBeanServer getMBeanServer();
+  @JsonIgnore LifecycleBean[] getLifecycleBeans();
+  @JsonIgnore IgniteLogger getGridLogger();
+  
+  @JsonDeserialize(converter = EventTypeConverter.class)
+  int[] getIncludeEventTypes();
+  
+}

--- a/src/main/java/io/vertx/spi/cluster/ignite/cfg/VertxLogger.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/cfg/VertxLogger.java
@@ -1,0 +1,134 @@
+package io.vertx.spi.cluster.ignite.cfg;
+
+import java.util.UUID;
+
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.internal.util.typedef.internal.A;
+import org.apache.ignite.logger.LoggerNodeIdAware;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * Logger to use with Vertx logging. Implementation simply delegates to Vertx
+ * Logging.
+ */
+public class VertxLogger implements IgniteLogger, LoggerNodeIdAware {
+
+  private final Logger logger;
+
+  private static final Object mux = new Object();
+
+  /** Node ID. */
+  private volatile UUID nodeId;
+
+  public VertxLogger() {
+    this.logger = LoggerFactory.getLogger("global");
+  }
+
+  public VertxLogger(Logger logger) {
+    this.logger = logger;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setNodeId(UUID nodeId) {
+    A.notNull(nodeId, "nodeId");
+
+    if (this.nodeId != null)
+      return;
+
+    synchronized (mux) {
+      // Double check.
+      if (this.nodeId != null)
+        return;
+
+      this.nodeId = nodeId;
+    }
+  }
+
+  @Override
+  public UUID getNodeId() {
+    return nodeId;
+  }
+
+  @Override
+  public IgniteLogger getLogger(Object ctgr) {
+    return new VertxLogger(ctgr == null ? LoggerFactory.getLogger("")
+        : LoggerFactory.getLogger(ctgr instanceof Class ? ((Class) ctgr).getName() : String.valueOf(ctgr)));
+  }
+
+  @Override
+  public void trace(String msg) {
+    if (nodeId != null)
+      logger.trace(logNodeId(msg));
+  }
+
+  private String logNodeId(String originalMessage) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("Ignite NODEID: ").append(nodeId).append(". ").append(originalMessage);
+    return builder.toString();
+  }
+
+  @Override
+  public void debug(String msg) {
+    if (nodeId != null)
+      logger.debug(msg);
+  }
+
+  @Override
+  public void info(String msg) {
+    if (nodeId != null)
+      logger.info(msg);
+  }
+
+  @Override
+  public void warning(String msg) {
+    if (nodeId != null)
+      logger.warn(msg);
+  }
+
+  @Override
+  public void warning(String msg, Throwable e) {
+    if (nodeId != null)
+      logger.warn(msg, e);
+  }
+
+  @Override
+  public void error(String msg) {
+    if (nodeId != null)
+      logger.error(msg);
+  }
+
+  @Override
+  public void error(String msg, Throwable e) {
+    if (nodeId != null)
+      logger.error(msg, e);
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return logger.isTraceEnabled();
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return logger.isInfoEnabled();
+  }
+
+  @Override
+  public boolean isQuiet() {
+    return nodeId == null;
+  }
+
+  @Override
+  public String fileName() {
+    return null;
+  }
+
+}

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/IgniteConfigurationLoaderImpl.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/IgniteConfigurationLoaderImpl.java
@@ -1,0 +1,88 @@
+package io.vertx.spi.cluster.ignite.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.apache.ignite.configuration.IgniteConfiguration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
+
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.spi.cluster.ignite.cfg.IgniteConfigurationLoader;
+import io.vertx.spi.cluster.ignite.cfg.IgniteConfigurationMixin;
+
+public class IgniteConfigurationLoaderImpl implements IgniteConfigurationLoader {
+
+  private final ObjectMapper mapper;
+
+  public IgniteConfigurationLoaderImpl() {
+    this.mapper = new ObjectMapper();
+    mapper.addMixIn(IgniteConfiguration.class, IgniteConfigurationMixin.class);
+    mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
+        .withFieldVisibility(JsonAutoDetect.Visibility.NONE).withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+        .withSetterVisibility(JsonAutoDetect.Visibility.PUBLIC_ONLY)
+        .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+    StdTypeResolverBuilder typeResolverBuilder = new ObjectMapper.DefaultTypeResolverBuilder(
+        DefaultTyping.NON_CONCRETE_AND_ARRAYS) {
+      @Override
+      public boolean useForType(JavaType t) {
+        while(t.isCollectionLikeType()) {
+          t = t.getContentType();
+        }
+        while (t.isArrayType()) {
+          t = t.getContentType();
+        }
+        // 19-Apr-2016, tatu: ReferenceType like Optional also requires similar
+        // handling:
+        while (t.isReferenceType()) {
+          t = t.getReferencedType();
+        }
+        return t.isJavaLangObject() || (!t.isConcrete()
+            // [databind#88] Should not apply to JSON tree models:
+            && !TreeNode.class.isAssignableFrom(t.getRawClass()));
+      }
+    };
+    typeResolverBuilder = typeResolverBuilder.init(JsonTypeInfo.Id.CLASS, null).inclusion(JsonTypeInfo.As.PROPERTY)
+        .typeProperty("@class");
+    mapper.setDefaultTyping(typeResolverBuilder);
+    mapper.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
+  }
+
+  @Override
+  public IgniteConfiguration fromJson(JsonObject json) {
+    String jsonStr = json.encode();
+    return fromJson(jsonStr);
+  }
+
+  @Override
+  public IgniteConfiguration fromJson(String jsonStr) {
+    IgniteConfiguration cfg;
+    try {
+      cfg = mapper.readValue(jsonStr, IgniteConfiguration.class);
+      return cfg;
+    } catch (IOException e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public IgniteConfiguration fromJson(InputStream is) {
+    IgniteConfiguration cfg;
+    try {
+      cfg = mapper.readValue(new InputStreamReader(is, "UTF-8"), IgniteConfiguration.class);
+      return cfg;
+    } catch (IOException e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
+  }
+
+}

--- a/src/main/resources/default-ignite.json
+++ b/src/main/resources/default-ignite.json
@@ -1,0 +1,18 @@
+{
+	"discoverySpi" : {
+		"@class" : "org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi",
+		"ipFinder" : {
+			"@class" : "org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder"
+		}
+	},
+	"cacheConfiguration" : [{
+		"name" : "*",
+		"cacheMode" : "PARTITIONED",
+        "backups" : 1,
+        "readFromBackup" : false
+	}],
+	"includeEventTypes" : [
+		"EVT_CACHE_OBJECT_REMOVED"
+	],
+	"metricsLogFrequency" : 0
+}

--- a/src/test/java/io/vertx/spi/cluster/ignite/IgniteConfigurationLoaderTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/IgniteConfigurationLoaderTest.java
@@ -1,0 +1,95 @@
+package io.vertx.spi.cluster.ignite;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
+
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.cache.affinity.AffinityFunction;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.events.EventType;
+import org.apache.ignite.spi.discovery.DiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.spi.cluster.ignite.cfg.IgniteConfigurationLoader;
+import io.vertx.spi.cluster.ignite.impl.IgniteConfigurationLoaderImpl;
+
+public class IgniteConfigurationLoaderTest {
+
+  IgniteConfigurationLoader loader;
+  
+  @Before
+  public void initLoader() {
+    this.loader = new IgniteConfigurationLoaderImpl();
+  }
+  
+  @Test
+  public void testDefaultConfiguration() throws Exception {
+    URL resource = getClass().getResource("/default-ignite.json");
+    String json = new String(Files.readAllBytes(Paths.get(resource.toURI())), "UTF-8");
+    IgniteConfiguration cfg = this.loader.fromJson(json);
+    Assert.assertEquals(0, cfg.getMetricsLogFrequency());
+    Assert.assertArrayEquals(new int[]{EventType.EVT_CACHE_OBJECT_REMOVED}, cfg.getIncludeEventTypes());
+    
+    DiscoverySpi discoverySpi = cfg.getDiscoverySpi();
+    Assert.assertNotNull(discoverySpi);
+    Assert.assertTrue(discoverySpi instanceof TcpDiscoverySpi);
+    TcpDiscoverySpi tcpDiscoverySpi = (TcpDiscoverySpi) discoverySpi;
+    TcpDiscoveryIpFinder ipFinder = tcpDiscoverySpi.getIpFinder();
+    Assert.assertNotNull(ipFinder);
+    Assert.assertTrue(ipFinder instanceof TcpDiscoveryMulticastIpFinder);
+    
+    CacheConfiguration[] cacheConfigurations = cfg.getCacheConfiguration();
+    Assert.assertNotNull(cacheConfigurations);
+    Assert.assertTrue(cacheConfigurations.length==1);
+    CacheConfiguration cacheConfiguration = cacheConfigurations[0];
+    Assert.assertEquals("*", cacheConfiguration.getName());
+    Assert.assertEquals(CacheMode.PARTITIONED, cacheConfiguration.getCacheMode());
+    Assert.assertEquals(1, cacheConfiguration.getBackups());
+    Assert.assertEquals(false, cacheConfiguration.isReadFromBackup());
+  }
+ 
+  @Test
+  public void testTestingConfiguration() throws Exception {
+    URL resource = getClass().getResource("/ignite.json");
+    String json = new String(Files.readAllBytes(Paths.get(resource.toURI())), "UTF-8");
+    IgniteConfiguration cfg = this.loader.fromJson(json);
+    Assert.assertEquals(0, cfg.getMetricsLogFrequency());
+    Assert.assertArrayEquals(new int[]{EventType.EVT_CACHE_OBJECT_REMOVED}, cfg.getIncludeEventTypes());
+    
+    DiscoverySpi discoverySpi = cfg.getDiscoverySpi();
+    Assert.assertNotNull(discoverySpi);
+    Assert.assertTrue(discoverySpi instanceof TcpDiscoverySpi);
+    TcpDiscoverySpi tcpDiscoverySpi = (TcpDiscoverySpi) discoverySpi;
+    TcpDiscoveryIpFinder ipFinder = tcpDiscoverySpi.getIpFinder();
+    Assert.assertNotNull(ipFinder);
+    Assert.assertTrue(ipFinder instanceof TcpDiscoveryVmIpFinder);
+    TcpDiscoveryVmIpFinder tcpDiscoveryVmIpFinder = (TcpDiscoveryVmIpFinder) ipFinder;
+    Collection<InetSocketAddress> registeredAddresses = tcpDiscoveryVmIpFinder.getRegisteredAddresses();
+    Assert.assertEquals(50, registeredAddresses.size());
+    InetSocketAddress address = registeredAddresses.iterator().next();
+    Assert.assertEquals("127.0.0.1", address.getAddress().getHostAddress());
+    
+    CacheConfiguration[] cacheConfigurations = cfg.getCacheConfiguration();
+    Assert.assertNotNull(cacheConfigurations);
+    Assert.assertTrue(cacheConfigurations.length==1);
+    CacheConfiguration cacheConfiguration = cacheConfigurations[0];
+    Assert.assertEquals("*", cacheConfiguration.getName());
+    Assert.assertEquals(CacheMode.PARTITIONED, cacheConfiguration.getCacheMode());
+    Assert.assertEquals(1, cacheConfiguration.getBackups());
+    Assert.assertEquals(false, cacheConfiguration.isReadFromBackup());
+    AffinityFunction affinity = cacheConfiguration.getAffinity(); 
+    Assert.assertNotNull(affinity);
+    Assert.assertEquals(128, affinity.partitions());
+  }
+  
+}

--- a/src/test/resources/ignite.json
+++ b/src/test/resources/ignite.json
@@ -1,0 +1,25 @@
+{
+	"localHost" : "127.0.0.1",
+	"discoverySpi" : {
+		"@class" : "org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi",
+		"ipFinder" : {
+			"@class" : "org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder",
+			"addresses" : ["127.0.0.1:47500..47549"]
+		}
+	},
+	"cacheConfiguration" : [{
+		"name" : "*",
+		"cacheMode" : "PARTITIONED",
+        "backups" : 1,
+        "readFromBackup" : false,
+        "startSize" : 15000,
+        "affinity" : {
+        	"@class" : "org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction",
+        	"partitions" : 128
+        }
+	}],
+	"includeEventTypes" : [
+		"EVT_CACHE_OBJECT_REMOVED"
+	],
+	"metricsLogFrequency" : 0
+}


### PR DESCRIPTION
I wrote a json config parser to make a dependency on ignite-spring and even whole spring stack unnecessary. It's only required to configure ignite from xml config file, so it's better to make it optional. In vertx it's best practice to configure things via json, so i wrote parser that replace this xml file (see my update of documentation) and made it default. Users can still use xml file if add dependency to ignite-spring, also documented.