### PR TITLE
Bugfix for duplicate key / value pair in AsyncMultiMap

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/AsyncMultiMapImpl.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/AsyncMultiMapImpl.java
@@ -99,10 +99,9 @@ public class AsyncMultiMapImpl<K, V> implements AsyncMultiMap<K, V> {
     execute(cache -> cache.invoke(key, (entry, arguments) -> {
       List<V> values = entry.getValue();
 
-      if (values == null)
+      if (values == null) {
         values = new ArrayList<>();
-
-      if (values.contains(value)) {
+      } else if (values.contains(value)) {
         return null;
       }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/AsyncMultiMapImpl.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/AsyncMultiMapImpl.java
@@ -102,6 +102,10 @@ public class AsyncMultiMapImpl<K, V> implements AsyncMultiMap<K, V> {
       if (values == null)
         values = new ArrayList<>();
 
+      if (values.contains(value)) {
+        return null;
+      }
+
       values.add(value);
       entry.setValue(values);
       return null;

--- a/src/test/java/io/vertx/test/core/IgniteClusterFaultToleranceTest.java
+++ b/src/test/java/io/vertx/test/core/IgniteClusterFaultToleranceTest.java
@@ -1,0 +1,16 @@
+package io.vertx.test.core;
+
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.spi.cluster.ignite.IgniteClusterManager;
+
+/**
+ * @author Guo Yu
+ */
+public class IgniteClusterFaultToleranceTest extends FaultToleranceTest {
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new IgniteClusterManager();
+  }
+
+}


### PR DESCRIPTION
According to the AsnycMultiMap interface definition, the key / value pairs in AsnycMultiMap should be **unique**. So it must check if the entry is already exists before add them to the cache list.
It will also cause the ClusterEventBus added duplicate registration information when node list has changed.

Signed-off-by: guoyu <guoyu.511@gmail.com>