### PR TITLE
NullPointerException when using a preconfigured ignite instance.

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -255,12 +255,14 @@ public class IgniteClusterManager implements ClusterManager {
           }
           nodeID = nodeId(ignite.cluster().localNode());
 
-          for (CacheConfiguration cacheCfg : ignite.configuration().getCacheConfiguration()) {
-            if (cacheCfg.getName().equals(VERTX_CACHE_TEMPLATE_NAME)) {
-              collectionCfg = new CollectionConfiguration();
-              collectionCfg.setAtomicityMode(cacheCfg.getAtomicityMode());
-              collectionCfg.setBackups(cacheCfg.getBackups());
-              break;
+          if(ignite.configuration().getCacheConfiguration() != null) {
+            for (CacheConfiguration cacheCfg : ignite.configuration().getCacheConfiguration()) {
+              if (cacheCfg.getName().equals(VERTX_CACHE_TEMPLATE_NAME)) {
+                collectionCfg = new CollectionConfiguration();
+                collectionCfg.setAtomicityMode(cacheCfg.getAtomicityMode());
+                collectionCfg.setBackups(cacheCfg.getBackups());
+                break;
+              }
             }
           }
 


### PR DESCRIPTION
When providing an ignite instance a Null pointer can be thrown. This fixes that issue. 