### PR TITLE
3.5.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,43 @@
+pipeline {
+  agent any
+  tools {
+    maven 'Maven'
+  }
+  environment {
+    MAVEN_SETTINGS_PATH = credentials("jenkins-sonatype-snapshot-repo-settings")
+  }
+  stages {
+    stage ('OracleJDK 8') {
+      tools {
+        jdk 'OracleJDK 8'
+      }
+      steps {
+        sh 'mvn -U -B -Dsurefire.reportNameSuffix=OracleJDK_8 clean deploy -s $MAVEN_SETTINGS_PATH'
+      }
+      post {
+        always {
+          junit '**/target/surefire-reports/*.xml'
+        }
+        failure {
+          mail to:'vertx3-ci@googlegroups.com', subject:"Job '${env.JOB_NAME}' (${env.BUILD_NUMBER})", body: "Please go to ${env.BUILD_URL}."
+        }
+      }
+    }
+    stage ('OracleJDK latest') {
+      tools {
+        jdk 'OracleJDK latest'
+      }
+      when {
+        branch 'master'
+      }
+      steps {
+        sh 'mvn -U -B -fn -Dsurefire.reportNameSuffix=OracleJDK_latest clean test'
+      }
+      post {
+        always {
+          junit '**/target/surefire-reports/*.xml'
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+library "vertx-shared-library@master"
 pipeline {
   agent any
   tools {
@@ -13,6 +14,7 @@ pipeline {
       }
       steps {
         sh 'mvn -U -B -Dsurefire.reportNameSuffix=OracleJDK_8 clean deploy -s $MAVEN_SETTINGS_PATH'
+        triggerWorkflow()
       }
       post {
         always {

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3</version>
+  <version>3.5.4-SNAPSHOT</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.3</stack.version>
+    <stack.version>3.5.4-SNAPSHOT</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2-SNAPSHOT</version>
+  <version>3.5.2</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2-SNAPSHOT</stack.version>
+    <stack.version>3.5.2</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2-SNAPSHOT</version>
+  <version>3.5.2.CR3</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2-SNAPSHOT</stack.version>
+    <stack.version>3.5.2.CR3</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2</version>
+  <version>3.5.3-SNAPSHOT</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2</stack.version>
+    <stack.version>3.5.3-SNAPSHOT</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3-SNAPSHOT</version>
+  <version>3.5.3.CR1</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.3-SNAPSHOT</stack.version>
+    <stack.version>3.5.3.CR1</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2-SNAPSHOT</version>
+  <version>3.5.2.CR2</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2-SNAPSHOT</stack.version>
+    <stack.version>3.5.2.CR2</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR1</version>
+  <version>3.5.2-SNAPSHOT</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2.CR1</stack.version>
+    <stack.version>3.5.2-SNAPSHOT</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR3</version>
+  <version>3.5.2-SNAPSHOT</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2.CR3</stack.version>
+    <stack.version>3.5.2-SNAPSHOT</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3.CR1</version>
+  <version>3.5.3-SNAPSHOT</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.3.CR1</stack.version>
+    <stack.version>3.5.3-SNAPSHOT</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2-SNAPSHOT</version>
+  <version>3.5.2.CR1</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2-SNAPSHOT</stack.version>
+    <stack.version>3.5.2.CR1</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR2</version>
+  <version>3.5.2-SNAPSHOT</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.2.CR2</stack.version>
+    <stack.version>3.5.2-SNAPSHOT</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3-SNAPSHOT</version>
+  <version>3.5.3</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.3-SNAPSHOT</stack.version>
+    <stack.version>3.5.3</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.1</version>
+  <version>3.5.2-SNAPSHOT</version>
 
   <name>Vert.x Ignite Cluster Manager</name>
 
   <properties>
-    <stack.version>3.5.1</stack.version>
+    <stack.version>3.5.2-SNAPSHOT</stack.version>
     <ignite.version>2.3.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.1</version>
+  <version>3.5.2.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2</version>
+  <version>3.5.3.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2'
+compile 'io.vertx:vertx-ignite:3.5.3.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3.CR1</version>
+  <version>3.5.3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.3.CR1'
+compile 'io.vertx:vertx-ignite:3.5.3'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR1</version>
+  <version>3.5.2.CR2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR3</version>
+  <version>3.5.2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR3'
+compile 'io.vertx:vertx-ignite:3.5.2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR2</version>
+  <version>3.5.2.CR3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR2'
+compile 'io.vertx:vertx-ignite:3.5.2.CR3'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.1</version>
+  <version>3.5.2.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2</version>
+  <version>3.5.3.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2'
+compile 'io.vertx:vertx-ignite:3.5.3.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3.CR1</version>
+  <version>3.5.3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.3.CR1'
+compile 'io.vertx:vertx-ignite:3.5.3'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR1</version>
+  <version>3.5.2.CR2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR3</version>
+  <version>3.5.2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR3'
+compile 'io.vertx:vertx-ignite:3.5.2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR2</version>
+  <version>3.5.2.CR3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR2'
+compile 'io.vertx:vertx-ignite:3.5.2.CR3'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.1</version>
+  <version>3.5.2.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2</version>
+  <version>3.5.3.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2'
+compile 'io.vertx:vertx-ignite:3.5.3.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3.CR1</version>
+  <version>3.5.3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.3.CR1'
+compile 'io.vertx:vertx-ignite:3.5.3'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR1</version>
+  <version>3.5.2.CR2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR3</version>
+  <version>3.5.2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR3'
+compile 'io.vertx:vertx-ignite:3.5.2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR2</version>
+  <version>3.5.2.CR3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR2'
+compile 'io.vertx:vertx-ignite:3.5.2.CR3'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.1</version>
+  <version>3.5.2.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2</version>
+  <version>3.5.3.CR1</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2'
+compile 'io.vertx:vertx-ignite:3.5.3.CR1'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.3.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.3.CR1</version>
+  <version>3.5.3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.3.CR1'
+compile 'io.vertx:vertx-ignite:3.5.3'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR1.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR1</version>
+  <version>3.5.2.CR2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR1'
+compile 'io.vertx:vertx-ignite:3.5.2.CR2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR3</version>
+  <version>3.5.2</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR3'
+compile 'io.vertx:vertx-ignite:3.5.2'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.5.2.CR2.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.5.2.CR3.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.5.2.CR2</version>
+  <version>3.5.2.CR3</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.5.2.CR2'
+compile 'io.vertx:vertx-ignite:3.5.2.CR3'
 ----
 
 ### Programmatically specifying cluster manager


### PR DESCRIPTION
Caused by: java.lang.ClassNotFoundException: io.vertx.spi.cluster.ignite.impl.AsyncMultiMapImpl
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381) ~[?:1.8.0_45]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[?:1.8.0_45]
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331) ~[?:1.8.0_45]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_45]
        at java.lang.Class.forName0(Native Method) ~[?:1.8.0_45]
        at java.lang.Class.forName(Class.java:348) ~[?:1.8.0_45]
        at org.apache.ignite.internal.util.IgniteUtils.forName(IgniteUtils.java:8497) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.MarshallerContextImpl.getClass(MarshallerContextImpl.java:331) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryContext.descriptorForTypeId(BinaryContext.java:688) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryContext.descriptorForTypeId(BinaryContext.java:694) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryUtils.doReadClass(BinaryUtils.java:1637) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryUtils.doReadClass(BinaryUtils.java:1574) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryUtils.doReadClass(BinaryUtils.java:1551) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryReaderExImpl.readClass(BinaryReaderExImpl.java:380) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryFieldAccessor$DefaultFinalClassAccessor.readFixedType(BinaryFieldAccessor.java:883) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryFieldAccessor$DefaultFinalClassAccessor.read0(BinaryFieldAccessor.java:679) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryFieldAccessor.read(BinaryFieldAccessor.java:164) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryClassDescriptor.read(BinaryClassDescriptor.java:843) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryReaderExImpl.deserialize0(BinaryReaderExImpl.java:1762) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryReaderExImpl.deserialize(BinaryReaderExImpl.java:1714) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.GridBinaryMarshaller.deserialize(GridBinaryMarshaller.java:310) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.binary.BinaryMarshaller.unmarshal0(BinaryMarshaller.java:99) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.marshaller.AbstractNodeNameAwareMarshaller.unmarshal(AbstractNodeNameAwareMarshaller.java:82) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.util.IgniteUtils.unmarshal(IgniteUtils.java:9795) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.GridCacheMessage.unmarshalCollection(GridCacheMessage.java:625) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.distributed.dht.atomic.GridNearAtomicFullUpdateRequest.finishUnmarshal(GridNearAtomicFullUpdateRequest.java:406) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.GridCacheIoManager.unmarshall(GridCacheIoManager.java:1526) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.GridCacheIoManager.onMessage0(GridCacheIoManager.java:574) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.GridCacheIoManager.handleMessage(GridCacheIoManager.java:378) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.GridCacheIoManager.handleMessage(GridCacheIoManager.java:304) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.GridCacheIoManager.access$100(GridCacheIoManager.java:99) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.processors.cache.GridCacheIoManager$1.onMessage(GridCacheIoManager.java:293) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.managers.communication.GridIoManager.invokeListener(GridIoManager.java:1555) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.managers.communication.GridIoManager.processRegularMessage0(GridIoManager.java:1183) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.managers.communication.GridIoManager.access$4200(GridIoManager.java:126) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.managers.communication.GridIoManager$9.run(GridIoManager.java:1090) ~[ignite-core-2.3.0.jar!/:2.3.0]
        at org.apache.ignite.internal.util.StripedExecutor$Stripe.run(StripedExecutor.java:505) ~[ignite-core-2.3.0.jar!/:2.3.0]
        ... 1 more