### PR TITLE
update ignite 2.3.0 to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <ignite.version>2.3.0</ignite.version>
+    <ignite.version>2.8.0</ignite.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>
 


### PR DESCRIPTION
Motivation:

In Apache Ignite 2.8.0 version
**GridDhtInvalidPartitionException** Class move 
org.apache.ignite.internal.processors.cache.distributed.dht.GridDhtInvalidPartitionException
from 
org.apache.ignite.internal.processors.cache.distributed.dht.topology


Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
