### PR TITLE
Run the listener for the subsmap helper on a different thread, Updated cache operations to async

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -283,40 +283,10 @@ public class IgniteClusterManager implements ClusterManager {
           }
           nodeId = nodeId(ignite.cluster().localNode());
 
-          eventListener = event -> {
-            if (!active) {
-              return false;
-            }
-
-            vertx.executeBlocking(f -> {
-              if (isActive()) {
-                switch (event.type()) {
-                  case EVT_NODE_JOINED:
-                    if (nodeListener != null) {
-                      nodeListener.nodeAdded(nodeId(((DiscoveryEvent) event).eventNode()));
-                    }
-                    break;
-                  case EVT_NODE_LEFT:
-                  case EVT_NODE_FAILED:
-                    String id = nodeId(((DiscoveryEvent) event).eventNode());
-                    if (isMaster()) {
-                      cleanSubs(id);
-                      cleanNodeInfos(id);
-                    }
-                    if (nodeListener != null) {
-                      nodeListener.nodeLeft(id);
-                    }
-                    break;
-                }
-              }
-              f.complete();
-            }, null);
-
-            return true;
-          };
+          eventListener = this::listen;
 
           ignite.events().localListen(eventListener, EVT_NODE_JOINED, EVT_NODE_LEFT, EVT_NODE_FAILED);
-          subsMapHelper = new SubsMapHelper(ignite, nodeSelector);
+          subsMapHelper = new SubsMapHelper(ignite, nodeSelector, vertx);
           nodeInfoMap = ignite.getOrCreateCache("__vertx.nodeInfo");
 
           prom.complete();
@@ -336,6 +306,7 @@ public class IgniteClusterManager implements ClusterManager {
             if (eventListener != null) {
               ignite.events().stopLocalListen(eventListener, EVT_NODE_JOINED, EVT_NODE_LEFT, EVT_NODE_FAILED);
             }
+            this.subsMapHelper.leave(ignite);
             if (!customIgnite) {
               ignite.close();
             }
@@ -378,6 +349,44 @@ public class IgniteClusterManager implements ClusterManager {
     }, false, promise);
   }
 
+  boolean listen(Event event) {
+    if (!active) {
+      return false;
+    }
+
+    vertx.executeBlocking(f -> {
+      if (isActive()) {
+        switch (event.type()) {
+          case EVT_NODE_JOINED:
+            if (nodeListener != null) {
+              nodeListener.nodeAdded(nodeId(((DiscoveryEvent) event).eventNode()));
+            }
+            break;
+          case EVT_NODE_LEFT:
+          case EVT_NODE_FAILED:
+            String id = nodeId(((DiscoveryEvent) event).eventNode());
+            if (isMaster()) {
+              cleanSubs(id);
+              cleanNodeInfos(id);
+            }
+            if (nodeListener != null) {
+              try {
+                nodeListener.nodeLeft(id);
+              } catch (Exception e) {
+                if (!e.getMessage().contains("Failed to send message")) {
+                  throw e;
+                }
+              }
+            }
+            break;
+        }
+      }
+      f.complete();
+    }, null);
+
+    return true;
+  }
+
   private boolean isMaster() {
     return nodeId(ignite.cluster()
       .forOldest().node())
@@ -388,7 +397,7 @@ public class IgniteClusterManager implements ClusterManager {
     try {
       subsMapHelper.removeAllForNode(id);
     } catch (IllegalStateException | CacheException e) {
-      //ignore
+      log.error("Failed to remove all subscribers", e);
     }
   }
 
@@ -396,7 +405,7 @@ public class IgniteClusterManager implements ClusterManager {
     try {
       nodeInfoMap.remove(nid);
     } catch (IllegalStateException | CacheException e) {
-      //ignore
+      log.error("Failed to remove node info", e);
     }
   }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -18,6 +18,9 @@ package io.vertx.spi.cluster.ignite.impl;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.VertxException;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationInfo;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
@@ -32,6 +35,7 @@ import javax.cache.Cache;
 import javax.cache.CacheException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
@@ -43,32 +47,21 @@ import static org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_REMOVED;
  * @author Lukas Prettenthaler
  */
 public class SubsMapHelper {
+  private static final Logger log = LoggerFactory.getLogger(SubsMapHelper.class);
   private final IgniteCache<IgniteRegistrationInfo, Boolean> map;
+  private IgnitePredicate<Event> eventListener;
 
-  public SubsMapHelper(Ignite ignite, NodeSelector nodeSelector) {
+  public SubsMapHelper(Ignite ignite, NodeSelector nodeSelector, VertxInternal vertxInternal) {
     map = ignite.getOrCreateCache("__vertx.subs");
+    this.eventListener = event -> this.listen(event, nodeSelector, vertxInternal);
 
-    ignite.events().localListen((IgnitePredicate<Event>) event -> {
-      if (!(event instanceof CacheEvent)) {
-        return true;
-      }
-      CacheEvent cacheEvent = (CacheEvent) event;
-      if (!Objects.equals(cacheEvent.cacheName(), map.getName())) {
-        return true;
-      }
-      String address = cacheEvent.<IgniteRegistrationInfo>key().address();
-      Promise<List<RegistrationInfo>> promise = Promise.promise();
-      promise.future().onSuccess(registrationInfos -> {
-        nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
-      });
-      get(address, promise);
-      return true;
-    }, EVT_CACHE_OBJECT_PUT, EVT_CACHE_OBJECT_REMOVED);
+    ignite.events().localListen(this.eventListener, EVT_CACHE_OBJECT_PUT, EVT_CACHE_OBJECT_REMOVED);
   }
 
   public void get(String address, Promise<List<RegistrationInfo>> promise) {
     try {
-      List<RegistrationInfo> infos = map.query(new ScanQuery<IgniteRegistrationInfo, Boolean>((k, v) -> k.address().equals(address)))
+      List<RegistrationInfo> infos = map.query(
+        new ScanQuery<IgniteRegistrationInfo, Boolean>((k, v) -> k.address().equals(address)))
         .getAll().stream()
         .map(Cache.Entry::getKey)
         .map(IgniteRegistrationInfo::registrationInfo)
@@ -98,16 +91,41 @@ public class SubsMapHelper {
   }
 
   public void removeAllForNode(String nodeId) {
-    List<IgniteRegistrationInfo> toRemove = map.query(new ScanQuery<IgniteRegistrationInfo, Boolean>((k, v) -> k.registrationInfo().nodeId().equals(nodeId)))
-      .getAll().stream()
-      .map(Cache.Entry::getKey)
-      .collect(Collectors.toList());
-    for (IgniteRegistrationInfo info : toRemove) {
-      try {
-        map.remove(info);
-      } catch (IllegalStateException | CacheException t) {
-        //ignore
-      }
+    Set<IgniteRegistrationInfo> toRemove =
+      map.query(new ScanQuery<IgniteRegistrationInfo, Boolean>((k, v) ->
+        k.registrationInfo().nodeId().equals(nodeId)))
+        .getAll().stream()
+        .map(Cache.Entry::getKey)
+        .collect(Collectors.toSet());
+    try {
+      map.removeAll(toRemove);
+    } catch (IllegalStateException | CacheException t) {
+      log.error("Failed to remove all subscribers", t);
     }
+  }
+
+  public void leave(Ignite ignite) {
+    if (eventListener != null) {
+      ignite.events().stopLocalListen(eventListener, EVT_CACHE_OBJECT_PUT, EVT_CACHE_OBJECT_REMOVED);
+    }
+  }
+
+  boolean listen(Event event, final NodeSelector nodeSelector, final VertxInternal vertxInternal) {
+    if (!(event instanceof CacheEvent)) {
+      return true;
+    }
+    CacheEvent cacheEvent = (CacheEvent) event;
+    if (!Objects.equals(cacheEvent.cacheName(), map.getName())) {
+      return true;
+    }
+
+    vertxInternal.<List<RegistrationInfo>>executeBlocking(listPromise -> {
+      String address = cacheEvent.<IgniteRegistrationInfo>key().address();
+      listPromise.future().onSuccess(registrationInfos ->
+        nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos)
+        ));
+      get(address, listPromise);
+    });
+    return true;
   }
 }


### PR DESCRIPTION
### Motivation:

It was observed that a lot of ignite operations were running in a blocking mode, thus blocking the main thread. The intent here is to move the blocking operations on a seperate thread, and make ignite cache operations async.
