### PR TITLE
Remove risk of potential distributed deadlock when removing set of subscriptions

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/IgniteRegistrationInfo.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/IgniteRegistrationInfo.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * @author Thomas Segismont
  * @author Lukas Prettenthaler
  */
-public class IgniteRegistrationInfo implements Binarylizable {
+public class IgniteRegistrationInfo implements Binarylizable, Comparable<IgniteRegistrationInfo> {
   private String address;
   private RegistrationInfo registrationInfo;
 
@@ -77,5 +77,10 @@ public class IgniteRegistrationInfo implements Binarylizable {
     int result = address.hashCode();
     result = 31 * result + registrationInfo.hashCode();
     return result;
+  }
+
+  @Override
+  public int compareTo(IgniteRegistrationInfo other) {
+    return Integer.compare(hashCode(), other.hashCode());
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -33,7 +33,7 @@ import javax.cache.Cache;
 import javax.cache.CacheException;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
@@ -88,10 +88,10 @@ public class SubsMapHelper {
   }
 
   public void removeAllForNode(String nodeId) {
-    Set<IgniteRegistrationInfo> toRemove = map.query(new ScanQuery<IgniteRegistrationInfo, Boolean>((k, v) -> k.registrationInfo().nodeId().equals(nodeId)))
+    TreeSet<IgniteRegistrationInfo> toRemove = map.query(new ScanQuery<IgniteRegistrationInfo, Boolean>((k, v) -> k.registrationInfo().nodeId().equals(nodeId)))
       .getAll().stream()
       .map(Cache.Entry::getKey)
-      .collect(Collectors.toSet());
+      .collect(Collectors.toCollection(TreeSet::new));
     try {
       map.removeAll(toRemove);
     } catch (IllegalStateException | CacheException t) {


### PR DESCRIPTION
Motivation:

The ignite recommendation is to use a sorted Set like a TreeSet when using removeAll on a cache

ref: https://issues.apache.org/jira/browse/IGNITE-12365
