### PR TITLE
Make default data region configurable

### DIFF
--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
@@ -36,6 +36,16 @@ public class IgniteOptionsConverter {
             obj.setConnectionsPerNode(((Number)member.getValue()).intValue());
           }
           break;
+        case "defaultRegionInitialSize":
+          if (member.getValue() instanceof Number) {
+            obj.setDefaultRegionInitialSize(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "defaultRegionMaxSize":
+          if (member.getValue() instanceof Number) {
+            obj.setDefaultRegionMaxSize(((Number)member.getValue()).longValue());
+          }
+          break;
         case "discoverySpi":
           if (member.getValue() instanceof JsonObject) {
             obj.setDiscoverySpi(new io.vertx.spi.cluster.ignite.IgniteDiscoveryOptions((io.vertx.core.json.JsonObject)member.getValue()));
@@ -107,6 +117,8 @@ public class IgniteOptionsConverter {
     }
     json.put("connectTimeout", obj.getConnectTimeout());
     json.put("connectionsPerNode", obj.getConnectionsPerNode());
+    json.put("defaultRegionInitialSize", obj.getDefaultRegionInitialSize());
+    json.put("defaultRegionMaxSize", obj.getDefaultRegionMaxSize());
     if (obj.getDiscoverySpi() != null) {
       json.put("discoverySpi", obj.getDiscoverySpi().toJson());
     }

--- a/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.apache.ignite.configuration.DataStorageConfiguration.*;
 import static org.apache.ignite.configuration.IgniteConfiguration.DFLT_METRICS_LOG_FREQ;
 import static org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi.*;
 import static org.apache.ignite.ssl.SslContextFactory.*;
@@ -42,6 +43,8 @@ public class IgniteOptionsTest {
     assertNull(options.getSslContextFactory().getTrustStoreFilePath());
     assertFalse(options.getSslContextFactory().isTrustAll());
     assertTrue(options.isShutdownOnSegmentation());
+    assertEquals(DFLT_DATA_REGION_INITIAL_SIZE, options.getDefaultRegionInitialSize());
+    assertEquals(DFLT_DATA_REGION_MAX_SIZE, options.getDefaultRegionMaxSize());
   }
 
   @Test
@@ -67,6 +70,8 @@ public class IgniteOptionsTest {
     assertNull(options.getSslContextFactory().getTrustStoreFilePath());
     assertFalse(options.getSslContextFactory().isTrustAll());
     assertTrue(options.isShutdownOnSegmentation());
+    assertEquals(DFLT_DATA_REGION_INITIAL_SIZE, options.getDefaultRegionInitialSize());
+    assertEquals(DFLT_DATA_REGION_MAX_SIZE, options.getDefaultRegionMaxSize());
   }
 
   private void checkConfig(IgniteOptions options, IgniteConfiguration config) {
@@ -107,6 +112,8 @@ public class IgniteOptionsTest {
     assertEquals(options.getCacheConfiguration().get(0).isOnheapCacheEnabled(), config.getCacheConfiguration()[0].isOnheapCacheEnabled());
     assertEquals(options.getCacheConfiguration().get(0).isReadFromBackup(), config.getCacheConfiguration()[0].isReadFromBackup());
     assertNotNull(config.getCacheConfiguration()[0].getExpiryPolicyFactory());
+    assertEquals(options.getDefaultRegionInitialSize(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().getInitialSize());
+    assertEquals(options.getDefaultRegionMaxSize(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().getMaxSize());
   }
 
   private IgniteOptions createIgniteOptions() {
@@ -155,7 +162,9 @@ public class IgniteOptionsTest {
         .setExpiryPolicy(new JsonObject()
           .put("type", "created")
           .put("duration", 60000L)
-        )));
+        )))
+      .setDefaultRegionInitialSize(40L * 1024 * 1024)
+      .setDefaultRegionMaxSize(100L * 1024 * 1024);
   }
 
   @Test
@@ -223,6 +232,8 @@ public class IgniteOptionsTest {
     assertEquals(options.getCacheConfiguration().get(0).isReadFromBackup(), json.getJsonArray("cacheConfiguration").getJsonObject(0).getBoolean("readFromBackup"));
     assertEquals(options.getCacheConfiguration().get(0).getExpiryPolicy().getString("type"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("expiryPolicy").getString("type"));
     assertEquals(options.getCacheConfiguration().get(0).getExpiryPolicy().getString("duration"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("expiryPolicy").getString("duration"));
+    assertEquals(options.getDefaultRegionInitialSize(), json.getLong("defaultRegionInitialSize").longValue());
+    assertEquals(options.getDefaultRegionMaxSize(), json.getLong("defaultRegionMaxSize").longValue());
   }
 
   @Test
@@ -285,7 +296,9 @@ public class IgniteOptionsTest {
     "    \"trustStoreFilePath\": \"src/test/resources/server.jks\",\n" +
     "    \"trustStorePassword\": \"123456\",\n" +
     "    \"trustStoreType\": \"JKS\"\n" +
-    "  }\n" +
+    "  },\n" +
+    "  \"defaultRegionInitialSize\": 41943040,\n" +
+    "  \"defaultRegionMaxSize\": 104857600\n" +
     "}";
 
   @Test

--- a/src/test/resources/ignite.json
+++ b/src/test/resources/ignite.json
@@ -23,6 +23,8 @@
       "writeSynchronizationMode": "FULL_SYNC"
     }
   ],
+  "defaultRegionInitialSize": 20971520,
+  "defaultRegionMaxSize": 41943040,
   "includeEventTypes": ["EVT_CACHE_OBJECT_PUT", "EVT_CACHE_OBJECT_REMOVED"],
   "metricsLogFrequency": 0,
   "shutdownOnSegmentation": false


### PR DESCRIPTION
Motivation:

It is quite common to reduce the initial size of the default data region (defaults to 256mb) as well as the max size (defaults to 20% physical mem) for low memory systems. Especially when deploying to container based resource limited environments.

This PR does as well change the inital size to 40mb when running the unit tests.