### PR TITLE
Extend Options to allow custom DiscoverySpi

### DIFF
--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -83,7 +83,7 @@ public class Examples {
       .setPemTrustOptions(pemTrust);
 
     VertxOptions options = new VertxOptions()
-      .setClusterManager(new IgniteClusterManager(igniteOptions.toJson()))
+      .setClusterManager(new IgniteClusterManager(igniteOptions))
       .setEventBusOptions(eventBusOptions);
 
     Vertx.clusteredVertx(options, res -> {

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -84,7 +84,7 @@ public class IgniteClusterManager implements ClusterManager {
   private NodeSelector nodeSelector;
 
   private IgniteConfiguration extCfg;
-  private IgniteOptions extJsonConfig;
+  private IgniteOptions extOptions;
   private URL extConfigUrl;
 
   private Ignite ignite;
@@ -144,8 +144,19 @@ public class IgniteClusterManager implements ClusterManager {
    */
   @SuppressWarnings("unused")
   public IgniteClusterManager(JsonObject jsonConfig) {
+    this(new IgniteOptions(jsonConfig));
+  }
+
+  /**
+   * Creates cluster manager instance with given IgniteOptions.
+   * Use this constructor in order to configure cluster manager programmatically.
+   *
+   * @param extOptions {@code IgniteOptions} options object.
+   */
+  @SuppressWarnings("unused")
+  public IgniteClusterManager(IgniteOptions extOptions) {
     setIgniteProperties();
-    extJsonConfig = new IgniteOptions(jsonConfig);
+    this.extOptions = extOptions;
   }
 
   /**
@@ -423,10 +434,10 @@ public class IgniteClusterManager implements ClusterManager {
     }
     if (cfg == null) {
       IgniteOptions options;
-      if (extJsonConfig == null) {
+      if (extOptions == null) {
         options = new IgniteOptions(ConfigHelper.lookupJsonConfiguration(this.getClass(), CONFIG_FILE, DEFAULT_CONFIG_FILE));
       } else {
-        options = extJsonConfig;
+        options = extOptions;
       }
       shutdownOnSegmentation = options.isShutdownOnSegmentation();
       cfg = ConfigHelper.toIgniteConfig(vertx, options)

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteDiscoveryOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteDiscoveryOptions.java
@@ -16,7 +16,9 @@
 package io.vertx.spi.cluster.ignite;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.json.JsonObject;
+import org.apache.ignite.spi.discovery.DiscoverySpi;
 
 /**
  * @author Lukas Prettenthaler
@@ -25,6 +27,7 @@ import io.vertx.core.json.JsonObject;
 public class IgniteDiscoveryOptions {
   private String type;
   private JsonObject properties;
+  private DiscoverySpi customSpi;
 
   /**
    * Default constructor
@@ -91,6 +94,28 @@ public class IgniteDiscoveryOptions {
    */
   public IgniteDiscoveryOptions setProperties(JsonObject properties) {
     this.properties = properties;
+    return this;
+  }
+
+  /**
+   * Get the custom DiscoverySpi instance.
+   *
+   * @return DiscoverySpi.
+   */
+  @GenIgnore
+  public DiscoverySpi getCustomSpi() {
+    return customSpi;
+  }
+
+  /**
+   * Sets a custom initialized DiscoverySpi. When a custom Spi is set all other properties are ignored.
+   *
+   * @param discoverySpi DiscoverySpi implementation.
+   * @return reference to this, for fluency
+   */
+  @GenIgnore
+  public IgniteDiscoveryOptions setCustomSpi(DiscoverySpi discoverySpi) {
+    this.customSpi = discoverySpi;
     return this;
   }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
@@ -222,6 +222,9 @@ public class ConfigHelper {
   }
 
   private static DiscoverySpi toDiscoverySpiConfig(IgniteDiscoveryOptions options) {
+    if(options.getCustomSpi() != null) {
+      return options.getCustomSpi();
+    }
     JsonObject properties = options.getProperties();
     switch (options.getType()) {
       case "TcpDiscoveryVmIpFinder":

--- a/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
@@ -6,6 +6,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.spi.cluster.ignite.util.ConfigHelper;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi;
+import org.apache.ignite.spi.discovery.DiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.junit.Test;
 
@@ -36,6 +37,7 @@ public class IgniteOptionsTest {
     assertEquals(DFLT_METRICS_LOG_FREQ, options.getMetricsLogFrequency());
     assertEquals("TcpDiscoveryMulticastIpFinder", options.getDiscoverySpi().getType());
     assertEquals(0, options.getDiscoverySpi().getProperties().size());
+    assertNull(options.getDiscoverySpi().getCustomSpi());
     assertEquals(0, options.getCacheConfiguration().size());
     assertNull(options.getSslContextFactory());
     assertTrue(options.isShutdownOnSegmentation());
@@ -57,6 +59,7 @@ public class IgniteOptionsTest {
     assertEquals(DFLT_METRICS_LOG_FREQ, options.getMetricsLogFrequency());
     assertEquals("TcpDiscoveryMulticastIpFinder", options.getDiscoverySpi().getType());
     assertEquals(0, options.getDiscoverySpi().getProperties().size());
+    assertNull(options.getDiscoverySpi().getCustomSpi());
     assertEquals(0, options.getCacheConfiguration().size());
     assertNull(options.getSslContextFactory());
     assertTrue(options.isShutdownOnSegmentation());
@@ -376,5 +379,17 @@ public class IgniteOptionsTest {
     assertEquals(options.getJksTrustOptions().getPath(), "src/test/resources/server.jks");
     assertEquals(options.getJksTrustOptions().getPassword(), "123456");
     assertEquals(ConfigHelper.toSslContextFactoryConfig(Vertx.vertx(), options).create().getProtocol(), "TLSv1.2");
+  }
+
+  @Test
+  public void testCustomDiscoverySpi() {
+    DiscoverySpi customSpi = new TcpDiscoverySpi();
+    IgniteOptions options = new IgniteOptions();
+    options.getDiscoverySpi().setCustomSpi(customSpi);
+    assertEquals(options.getDiscoverySpi().getProperties(), new JsonObject());
+    assertEquals(options.getDiscoverySpi().getType(), "TcpDiscoveryMulticastIpFinder");
+    assertEquals(options.getDiscoverySpi().getCustomSpi(), customSpi);
+    IgniteConfiguration cfg = ConfigHelper.toIgniteConfig(Vertx.vertx(), options);
+    assertEquals(cfg.getDiscoverySpi(), customSpi);
   }
 }


### PR DESCRIPTION
Motivation:

Allow to override `IgniteDiscoveryOptions` with custom DiscoverySpi
This supports adding discoveries like `TcpDiscoveryKubernetesIpFinder` or any other implementing the `DiscoverySpi`