### PR TITLE
Replace global cache events with continuous query

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -114,7 +114,6 @@ In the example below the default config is extended to activate TLS for cluster 
     },
     "trustAll": false
   },
-  "includeEventTypes": ["EVT_CACHE_OBJECT_PUT", "EVT_CACHE_OBJECT_REMOVED"],
   "metricsLogFrequency": 0,
   "shutdownOnSegmentation": true
 }
@@ -189,13 +188,6 @@ Then add an `ignite.xml` file like this one:
           </property>
           <property name="writeSynchronizationMode" value="FULL_SYNC"/>
         </bean>
-      </list>
-    </property>
-
-    <property name="includeEventTypes">
-      <list>
-        <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_PUT"/>
-        <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_REMOVED"/>
       </list>
     </property>
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -91,7 +91,6 @@ In the example below the default config is extended to activate TLS for cluster 
   "cacheConfiguration": [{
     "name": "__vertx.*",
     "cacheMode": "REPLICATED",
-    "readFromBackup": false,
     "atomicityMode": "ATOMIC",
     "writeSynchronizationMode": "FULL_SYNC"
   }, {
@@ -171,7 +170,6 @@ Then add an `ignite.xml` file like this one:
         <bean class="org.apache.ignite.configuration.CacheConfiguration">
           <property name="name" value="__vertx.*"/>
           <property name="cacheMode" value="REPLICATED"/>
-          <property name="readFromBackup" value="false"/>
           <property name="atomicityMode" value="ATOMIC"/>
           <property name="writeSynchronizationMode" value="FULL_SYNC"/>
         </bean>

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
@@ -56,16 +56,6 @@ public class IgniteOptionsConverter {
             obj.setIdleConnectionTimeout(((Number)member.getValue()).longValue());
           }
           break;
-        case "includeEventTypes":
-          if (member.getValue() instanceof JsonArray) {
-            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                list.add((String)item);
-            });
-            obj.setIncludeEventTypes(list);
-          }
-          break;
         case "localHost":
           if (member.getValue() instanceof String) {
             obj.setLocalHost((String)member.getValue());
@@ -123,11 +113,6 @@ public class IgniteOptionsConverter {
       json.put("discoverySpi", obj.getDiscoverySpi().toJson());
     }
     json.put("idleConnectionTimeout", obj.getIdleConnectionTimeout());
-    if (obj.getIncludeEventTypes() != null) {
-      JsonArray array = new JsonArray();
-      obj.getIncludeEventTypes().forEach(item -> array.add(item));
-      json.put("includeEventTypes", array);
-    }
     if (obj.getLocalHost() != null) {
       json.put("localHost", obj.getLocalHost());
     }

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -356,7 +356,7 @@ public class IgniteClusterManager implements ClusterManager {
             if (eventListener != null) {
               ignite.events().stopLocalListen(eventListener, IGNITE_EVENTS);
             }
-            subsMapHelper.leave(ignite);
+            subsMapHelper.leave();
             if (!customIgnite) {
               ignite.close();
             }

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
@@ -16,7 +16,6 @@
 package io.vertx.spi.cluster.ignite;
 
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
 import java.util.*;
@@ -37,7 +36,6 @@ public class IgniteOptions {
   private long idleConnectionTimeout;
   private long maxConnectTimeout;
   private int reconnectCount;
-  private List<String> includeEventTypes;
   private long metricsLogFrequency;
   private IgniteDiscoveryOptions discoveryOptions;
   private List<IgniteCacheOptions> cacheConfiguration;
@@ -56,7 +54,6 @@ public class IgniteOptions {
     idleConnectionTimeout = DFLT_IDLE_CONN_TIMEOUT;
     reconnectCount = DFLT_RECONNECT_CNT;
     maxConnectTimeout = DFLT_MAX_CONN_TIMEOUT;
-    includeEventTypes = new ArrayList<>();
     metricsLogFrequency = DFLT_METRICS_LOG_FREQ;
     discoveryOptions = new IgniteDiscoveryOptions();
     cacheConfiguration = new ArrayList<>();
@@ -78,7 +75,6 @@ public class IgniteOptions {
     this.idleConnectionTimeout = options.idleConnectionTimeout;
     this.reconnectCount = options.reconnectCount;
     this.maxConnectTimeout = options.maxConnectTimeout;
-    this.includeEventTypes = options.includeEventTypes;
     this.metricsLogFrequency = options.metricsLogFrequency;
     this.discoveryOptions = options.discoveryOptions;
     this.cacheConfiguration = options.cacheConfiguration;
@@ -244,27 +240,6 @@ public class IgniteOptions {
    */
   public IgniteOptions setReconnectCount(int reconnectCount) {
     this.reconnectCount = reconnectCount;
-    return this;
-  }
-
-  /**
-   * Gets array of event types, which will be recorded.
-   *
-   * @return Include event types.
-   */
-  public List<String> getIncludeEventTypes() {
-    return includeEventTypes;
-  }
-
-  /**
-   * Sets array of event types, which will be recorded by {@link IgniteClusterManager#join(Promise)}.
-   * Note, that either the include event types or the exclude event types can be established.
-   *
-   * @param includeEventTypes Include event types.
-   * @return reference to this, for fluency
-   */
-  public IgniteOptions setIncludeEventTypes(List<String> includeEventTypes) {
-    this.includeEventTypes = includeEventTypes;
     return this;
   }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -24,39 +24,42 @@ import io.vertx.core.spi.cluster.RegistrationInfo;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.query.ContinuousQuery;
 import org.apache.ignite.cache.query.ScanQuery;
-import org.apache.ignite.events.CacheEvent;
-import org.apache.ignite.events.Event;
-import org.apache.ignite.lang.IgnitePredicate;
 
 import javax.cache.Cache;
 import javax.cache.CacheException;
+import javax.cache.event.CacheEntryEvent;
 import java.util.List;
-import java.util.Objects;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.ignite.events.EventType.*;
 
 /**
  * @author Thomas Segismont
  * @author Lukas Prettenthaler
  */
 public class SubsMapHelper {
-  private static final int[] CACHE_EVENTS = new int[]{EVT_CACHE_OBJECT_PUT, EVT_CACHE_OBJECT_REMOVED};
-
   private final IgniteCache<IgniteRegistrationInfo, Boolean> map;
-  private final IgnitePredicate<Event> eventListener;
+  private boolean shutdown;
 
   public SubsMapHelper(Ignite ignite, NodeSelector nodeSelector, VertxInternal vertxInternal) {
     map = ignite.getOrCreateCache("__vertx.subs");
-    eventListener = event -> listen(event, nodeSelector, vertxInternal);
-
-    ignite.events().localListen(eventListener, CACHE_EVENTS);
+    map.query(new ContinuousQuery<IgniteRegistrationInfo, Boolean>()
+      .setAutoUnsubscribe(true)
+      .setTimeInterval(100L)
+      .setPageSize(128)
+      .setLocalListener(l -> listen(l, nodeSelector, vertxInternal)));
+    shutdown = false;
   }
 
   public void get(String address, Promise<List<RegistrationInfo>> promise) {
+    if (shutdown) {
+      promise.complete(null);
+      return;
+    }
     try {
       List<RegistrationInfo> infos = map.query(new ScanQuery<IgniteRegistrationInfo, Boolean>((k, v) -> k.address().equals(address)))
         .getAll().stream()
@@ -70,6 +73,9 @@ public class SubsMapHelper {
   }
 
   public Future<Void> put(String address, RegistrationInfo registrationInfo) {
+    if (shutdown) {
+      return Future.failedFuture(new VertxException("shutdown in progress"));
+    }
     try {
       map.put(new IgniteRegistrationInfo(address, registrationInfo), Boolean.TRUE);
     } catch (IllegalStateException | CacheException e) {
@@ -79,6 +85,10 @@ public class SubsMapHelper {
   }
 
   public void remove(String address, RegistrationInfo registrationInfo, Promise<Void> promise) {
+    if (shutdown) {
+      promise.complete();
+      return;
+    }
     try {
       map.remove(new IgniteRegistrationInfo(address, registrationInfo));
       promise.complete();
@@ -99,27 +109,23 @@ public class SubsMapHelper {
     }
   }
 
-  boolean listen(Event event, final NodeSelector nodeSelector, final VertxInternal vertxInternal) {
-    if (!(event instanceof CacheEvent)) {
-      return true;
-    }
-    CacheEvent cacheEvent = (CacheEvent) event;
-    if (!Objects.equals(cacheEvent.cacheName(), map.getName())) {
-      return true;
-    }
-    vertxInternal.<List<RegistrationInfo>>executeBlocking(promise -> {
-      String address = cacheEvent.<IgniteRegistrationInfo>key().address();
-      promise.future().onSuccess(registrationInfos -> {
-        nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
-      });
-      get(address, promise);
-    });
-    return true;
+  public void leave() {
+    shutdown = true;
   }
 
-  public void leave(Ignite ignite) {
-    if (eventListener != null) {
-      ignite.events().stopLocalListen(eventListener, CACHE_EVENTS);
-    }
+  private void listen(final Iterable<CacheEntryEvent<? extends IgniteRegistrationInfo, ? extends Boolean>> events, final NodeSelector nodeSelector, final VertxInternal vertxInternal) {
+    vertxInternal.<List<RegistrationInfo>>executeBlocking(promise -> {
+      StreamSupport.stream(events.spliterator(), false)
+        .map(e -> e.getKey().address())
+        .distinct()
+        .forEach(address -> {
+          Promise<List<RegistrationInfo>> prom = Promise.promise();
+          prom.future().onSuccess(registrationInfos -> {
+            nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
+          });
+          get(address, prom);
+        });
+      promise.complete();
+    });
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -43,7 +43,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class SubsMapHelper {
   private final IgniteCache<IgniteRegistrationInfo, Boolean> map;
-  private boolean shutdown;
+  private volatile boolean shutdown;
 
   public SubsMapHelper(Ignite ignite, NodeSelector nodeSelector, VertxInternal vertxInternal) {
     map = ignite.getOrCreateCache("__vertx.subs");

--- a/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
@@ -122,10 +122,6 @@ public class ConfigHelper {
       .setIdleConnectionTimeout(options.getIdleConnectionTimeout())
       .setMaxConnectTimeout(options.getMaxConnectTimeout())
       .setReconnectCount(options.getReconnectCount()));
-    configuration.setIncludeEventTypes(options.getIncludeEventTypes().stream()
-      .map(IgniteEventType::valueOf)
-      .mapToInt(IgniteEventType::toInt)
-      .toArray());
     configuration.setMetricsLogFrequency(options.getMetricsLogFrequency());
     configuration.setDiscoverySpi(toDiscoverySpiConfig(options.getDiscoverySpi()));
     configuration.setCacheConfiguration(options.getCacheConfiguration().stream()

--- a/src/main/resources/default-ignite.json
+++ b/src/main/resources/default-ignite.json
@@ -3,7 +3,6 @@
     {
       "name": "__vertx.*",
       "cacheMode": "REPLICATED",
-      "readFromBackup": false,
       "atomicityMode": "ATOMIC",
       "writeSynchronizationMode": "FULL_SYNC"
     }, {

--- a/src/test/java/io/vertx/Lifecycle.java
+++ b/src/test/java/io/vertx/Lifecycle.java
@@ -46,7 +46,7 @@ public class Lifecycle {
   public static void closeClustered(List<Vertx> clustered) throws Exception {
     CountDownLatch latch = new CountDownLatch(clustered.size());
     for (Vertx clusteredVertx : clustered) {
-      Thread.sleep(500L);
+      Thread.sleep(100L);
       clusteredVertx.close(ar -> {
         if (ar.failed()) {
           log.error("Failed to shutdown vert.x", ar.cause());
@@ -56,7 +56,7 @@ public class Lifecycle {
     }
     assertTrue(latch.await(180, TimeUnit.SECONDS));
 
-    Thread.sleep(200L);
+    Thread.sleep(100L);
 
     Collection<Ignite> list = new ArrayList<>(G.allGrids());
 

--- a/src/test/java/io/vertx/Lifecycle.java
+++ b/src/test/java/io/vertx/Lifecycle.java
@@ -46,7 +46,7 @@ public class Lifecycle {
   public static void closeClustered(List<Vertx> clustered) throws Exception {
     CountDownLatch latch = new CountDownLatch(clustered.size());
     for (Vertx clusteredVertx : clustered) {
-      Thread.sleep(100L);
+      Thread.sleep(500L);
       clusteredVertx.close(ar -> {
         if (ar.failed()) {
           log.error("Failed to shutdown vert.x", ar.cause());
@@ -56,7 +56,7 @@ public class Lifecycle {
     }
     assertTrue(latch.await(180, TimeUnit.SECONDS));
 
-    Thread.sleep(100L);
+    Thread.sleep(200L);
 
     Collection<Ignite> list = new ArrayList<>(G.allGrids());
 

--- a/src/test/java/io/vertx/core/eventbus/IgniteClusteredEventbusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/IgniteClusteredEventbusTest.java
@@ -20,7 +20,7 @@ package io.vertx.core.eventbus;
 import io.vertx.Lifecycle;
 import io.vertx.LoggingTestWatcher;
 import io.vertx.core.Vertx;
-import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.cluster.*;
 import io.vertx.spi.cluster.ignite.IgniteClusterManager;
 import org.junit.Rule;
 

--- a/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
@@ -10,10 +10,7 @@ import org.apache.ignite.spi.discovery.DiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.apache.ignite.configuration.DataStorageConfiguration.*;
 import static org.apache.ignite.configuration.IgniteConfiguration.DFLT_METRICS_LOG_FREQ;
@@ -27,7 +24,6 @@ public class IgniteOptionsTest {
   public void defaults() {
     IgniteOptions options = new IgniteOptions();
     assertNull(options.getLocalHost());
-    assertEquals(0, options.getIncludeEventTypes().size());
     assertEquals(DFLT_PORT, options.getLocalPort());
     assertEquals(DFLT_CONN_PER_NODE, options.getConnectionsPerNode());
     assertEquals(DFLT_CONN_TIMEOUT, options.getConnectTimeout());
@@ -49,7 +45,6 @@ public class IgniteOptionsTest {
   public void fromEmptyJson() {
     IgniteOptions options = new IgniteOptions(new JsonObject());
     assertNull(options.getLocalHost());
-    assertEquals(0, options.getIncludeEventTypes().size());
     assertEquals(DFLT_PORT, options.getLocalPort());
     assertEquals(DFLT_CONN_PER_NODE, options.getConnectionsPerNode());
     assertEquals(DFLT_CONN_TIMEOUT, options.getConnectTimeout());
@@ -76,10 +71,6 @@ public class IgniteOptionsTest {
     assertEquals(options.getIdleConnectionTimeout(), ((TcpCommunicationSpi) config.getCommunicationSpi()).getIdleConnectionTimeout());
     assertEquals(options.getMaxConnectTimeout(), ((TcpCommunicationSpi) config.getCommunicationSpi()).getMaxConnectTimeout());
     assertEquals(options.getReconnectCount(), ((TcpCommunicationSpi) config.getCommunicationSpi()).getReconnectCount());
-    assertEquals(options.getIncludeEventTypes(), Arrays.stream(config.getIncludeEventTypes())
-      .mapToObj(ConfigHelper.IgniteEventType::valueOf)
-      .map(Objects::toString)
-      .collect(Collectors.toList()));
     assertEquals(options.getMetricsLogFrequency(), config.getMetricsLogFrequency());
     assertEquals("TcpDiscoverySpi", config.getDiscoverySpi().getName());
     assertEquals(options.getDiscoverySpi().getProperties().getLong("joinTimeout").longValue(), ((TcpDiscoverySpi) config.getDiscoverySpi()).getJoinTimeout());
@@ -118,7 +109,6 @@ public class IgniteOptionsTest {
       .setIdleConnectionTimeout(300_000L)
       .setMaxConnectTimeout(200_000L)
       .setReconnectCount(20)
-      .setIncludeEventTypes(Arrays.asList("EVT_CACHE_OBJECT_PUT", "EVT_CACHE_OBJECT_REMOVED"))
       .setMetricsLogFrequency(10L)
       .setDiscoverySpi(new IgniteDiscoveryOptions()
         .setType("TcpDiscoveryVmIpFinder")
@@ -175,13 +165,6 @@ public class IgniteOptionsTest {
     ConfigHelper.toIgniteConfig(Vertx.vertx(), options);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void unsupportedEventType() {
-    IgniteOptions options = new IgniteOptions()
-      .setIncludeEventTypes(Arrays.asList("EVT_NOT_EXISTING1", "EVT_NOT_EXISTING2"));
-    ConfigHelper.toIgniteConfig(Vertx.vertx(), options);
-  }
-
   private void checkJson(IgniteOptions options, JsonObject json) {
     assertEquals(options.getLocalHost(), json.getString("localHost"));
     assertEquals(options.getLocalPort(), json.getInteger("localPort").intValue());
@@ -190,7 +173,6 @@ public class IgniteOptionsTest {
     assertEquals(options.getIdleConnectionTimeout(), json.getLong("idleConnectionTimeout").longValue());
     assertEquals(options.getMaxConnectTimeout(), json.getLong("maxConnectTimeout").longValue());
     assertEquals(options.getReconnectCount(), json.getInteger("reconnectCount").intValue());
-    assertEquals(options.getIncludeEventTypes(), json.getJsonArray("includeEventTypes").getList());
     assertEquals(options.getMetricsLogFrequency(), json.getLong("metricsLogFrequency").longValue());
     assertEquals(options.isShutdownOnSegmentation(), json.getBoolean("shutdownOnSegmentation"));
     assertEquals(options.getDiscoverySpi().getType(), json.getJsonObject("discoverySpi").getString("type"));
@@ -240,7 +222,6 @@ public class IgniteOptionsTest {
     "  \"connectTimeout\": 2000,\n" +
     "  \"connectionsPerNode\": 2,\n" +
     "  \"idleConnectionTimeout\": 300000,\n" +
-    "  \"includeEventTypes\": [\"EVT_CACHE_OBJECT_PUT\", \"EVT_CACHE_OBJECT_REMOVED\"],\n" +
     "  \"localHost\": \"localHost\",\n" +
     "  \"localPort\": 12345,\n" +
     "  \"maxConnectTimeout\": 200000,\n" +

--- a/src/test/resources/ignite-test.xml
+++ b/src/test/resources/ignite-test.xml
@@ -37,7 +37,6 @@
         <bean class="org.apache.ignite.configuration.CacheConfiguration">
           <property name="name" value="__vertx.*"/>
           <property name="cacheMode" value="REPLICATED"/>
-          <property name="readFromBackup" value="false"/>
           <property name="atomicityMode" value="ATOMIC"/>
           <property name="writeSynchronizationMode" value="FULL_SYNC"/>
         </bean>

--- a/src/test/resources/ignite-test.xml
+++ b/src/test/resources/ignite-test.xml
@@ -2,11 +2,8 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans.xsd
-                           http://www.springframework.org/schema/util
-                           http://www.springframework.org/schema/util/spring-util.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <bean class="org.apache.ignite.configuration.IgniteConfiguration">
 
@@ -57,13 +54,6 @@
           </property>
           <property name="writeSynchronizationMode" value="FULL_SYNC"/>
         </bean>
-      </list>
-    </property>
-
-    <property name="includeEventTypes">
-      <list>
-        <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_PUT"/>
-        <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_REMOVED"/>
       </list>
     </property>
 

--- a/src/test/resources/ignite.json
+++ b/src/test/resources/ignite.json
@@ -11,7 +11,6 @@
     {
       "name": "__vertx.*",
       "cacheMode": "REPLICATED",
-      "readFromBackup": false,
       "atomicityMode": "ATOMIC",
       "writeSynchronizationMode": "FULL_SYNC"
     }, {

--- a/src/test/resources/ignite.json
+++ b/src/test/resources/ignite.json
@@ -25,7 +25,6 @@
   ],
   "defaultRegionInitialSize": 20971520,
   "defaultRegionMaxSize": 41943040,
-  "includeEventTypes": ["EVT_CACHE_OBJECT_PUT", "EVT_CACHE_OBJECT_REMOVED"],
   "metricsLogFrequency": 0,
   "shutdownOnSegmentation": false
 }


### PR DESCRIPTION
Motivation:

Uses `ContinuousQuery` to replace cluster global `EVT_CACHE_OBJECT_PUT ` and `EVT_CACHE_OBJECT_REMOVED ` events which were affecting the performance of every cache write operation.

Fixes https://github.com/vert-x3/vertx-ignite/issues/108
