### PR TITLE
Prevent race during node listener registration

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -186,7 +186,7 @@ public class IgniteClusterManager implements ClusterManager {
   }
 
   @Override
-  public void nodeListener(NodeListener nodeListener) {
+  public synchronized void nodeListener(NodeListener nodeListener) {
     this.nodeListener = nodeListener;
   }
 


### PR DESCRIPTION
Motivation:

There are some edge cases were a `nodeListener` registration can fail (different threads accessing the cluster manager)
Synchronizing this method solves that issue