### PR TITLE
Perf improvements in subscription event handling

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -160,14 +160,17 @@ public class SubsMapHelper {
     throttling.onEvent(address);
   }
 
-  private void getAndUpdate(String address) {
+  private Future<List<RegistrationInfo>> getAndUpdate(String address) {
     Promise<List<RegistrationInfo>> prom = Promise.promise();
-    prom.future().onSuccess(registrationInfos -> {
-      nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
-    });
     if (nodeSelector.wantsUpdatesFor(address)) {
+      prom.future().onSuccess(registrationInfos -> {
+        nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
+      });
       get(address, prom);
+    } else {
+      prom.complete();
     }
+    return prom.future();
   }
 
   private void listen(final Iterable<CacheEntryEvent<? extends IgniteRegistrationInfo, ? extends Boolean>> events, final VertxInternal vertxInternal) {

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -30,8 +30,9 @@ import org.apache.ignite.cache.query.ScanQuery;
 import javax.cache.Cache;
 import javax.cache.CacheException;
 import javax.cache.event.CacheEntryEvent;
-import java.util.List;
-import java.util.TreeSet;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -43,16 +44,21 @@ import static java.util.stream.Collectors.toList;
  */
 public class SubsMapHelper {
   private final IgniteCache<IgniteRegistrationInfo, Boolean> map;
+  private final NodeSelector nodeSelector;
+  private final ConcurrentMap<String, Set<RegistrationInfo>> localSubs = new ConcurrentHashMap<>();
+  private final Throttling throttling;
   private volatile boolean shutdown;
 
   public SubsMapHelper(Ignite ignite, NodeSelector nodeSelector, VertxInternal vertxInternal) {
     map = ignite.getOrCreateCache("__vertx.subs");
+    this.nodeSelector = nodeSelector;
+    throttling = new Throttling(vertxInternal, this::getAndUpdate);
+    shutdown = false;
     map.query(new ContinuousQuery<IgniteRegistrationInfo, Boolean>()
       .setAutoUnsubscribe(true)
       .setTimeInterval(100L)
       .setPageSize(128)
-      .setLocalListener(l -> listen(l, nodeSelector, vertxInternal)));
-    shutdown = false;
+      .setLocalListener(l -> listen(l, vertxInternal)));
   }
 
   public void get(String address, Promise<List<RegistrationInfo>> promise) {
@@ -66,6 +72,22 @@ public class SubsMapHelper {
         .map(Cache.Entry::getKey)
         .map(IgniteRegistrationInfo::registrationInfo)
         .collect(toList());
+      int size = infos.size();
+      Set<RegistrationInfo> local = localSubs.get(address);
+      if (local != null) {
+        synchronized (local) {
+          size += local.size();
+          if (size == 0) {
+            promise.complete(Collections.emptyList());
+            return;
+          }
+          infos.addAll(local);
+        }
+      } else if (size == 0) {
+        promise.complete(Collections.emptyList());
+        return;
+      }
+
       promise.complete(infos);
     } catch (IllegalStateException | CacheException e) {
       promise.fail(new VertxException(e));
@@ -77,11 +99,22 @@ public class SubsMapHelper {
       return Future.failedFuture(new VertxException("shutdown in progress"));
     }
     try {
-      map.put(new IgniteRegistrationInfo(address, registrationInfo), Boolean.TRUE);
+      if (registrationInfo.localOnly()) {
+        localSubs.compute(address, (add, curr) -> addToSet(registrationInfo, curr));
+        fireLocalRegistrationUpdateEvent(address);
+      } else {
+        map.put(new IgniteRegistrationInfo(address, registrationInfo), Boolean.TRUE);
+      }
     } catch (IllegalStateException | CacheException e) {
       return Future.failedFuture(new VertxException(e));
     }
     return Future.succeededFuture();
+  }
+
+  private Set<RegistrationInfo> addToSet(RegistrationInfo registrationInfo, Set<RegistrationInfo> curr) {
+    Set<RegistrationInfo> res = curr != null ? curr : Collections.synchronizedSet(new LinkedHashSet<>());
+    res.add(registrationInfo);
+    return res;
   }
 
   public void remove(String address, RegistrationInfo registrationInfo, Promise<Void> promise) {
@@ -90,11 +123,21 @@ public class SubsMapHelper {
       return;
     }
     try {
-      map.remove(new IgniteRegistrationInfo(address, registrationInfo));
+      if (registrationInfo.localOnly()) {
+        localSubs.computeIfPresent(address, (add, curr) -> removeFromSet(registrationInfo, curr));
+        fireLocalRegistrationUpdateEvent(address);
+      } else {
+        map.remove(new IgniteRegistrationInfo(address, registrationInfo));
+      }
       promise.complete();
     } catch (IllegalStateException | CacheException e) {
       promise.fail(new VertxException(e));
     }
+  }
+
+  private Set<RegistrationInfo> removeFromSet(RegistrationInfo registrationInfo, Set<RegistrationInfo> curr) {
+    curr.remove(registrationInfo);
+    return curr.isEmpty() ? null : curr;
   }
 
   public void removeAllForNode(String nodeId) {
@@ -113,18 +156,24 @@ public class SubsMapHelper {
     shutdown = true;
   }
 
-  private void listen(final Iterable<CacheEntryEvent<? extends IgniteRegistrationInfo, ? extends Boolean>> events, final NodeSelector nodeSelector, final VertxInternal vertxInternal) {
+  private void fireLocalRegistrationUpdateEvent(String address) {
+    throttling.onEvent(address);
+  }
+
+  private void getAndUpdate(String address) {
+    Promise<List<RegistrationInfo>> prom = Promise.promise();
+    prom.future().onSuccess(registrationInfos -> {
+      nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
+    });
+    get(address, prom);
+  }
+
+  private void listen(final Iterable<CacheEntryEvent<? extends IgniteRegistrationInfo, ? extends Boolean>> events, final VertxInternal vertxInternal) {
     vertxInternal.<List<RegistrationInfo>>executeBlocking(promise -> {
       StreamSupport.stream(events.spliterator(), false)
         .map(e -> e.getKey().address())
         .distinct()
-        .forEach(address -> {
-          Promise<List<RegistrationInfo>> prom = Promise.promise();
-          prom.future().onSuccess(registrationInfos -> {
-            nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
-          });
-          get(address, prom);
-        });
+        .forEach(this::getAndUpdate);
       promise.complete();
     });
   }

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/Throttling.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/Throttling.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.spi.cluster.ignite.impl;
+
+import io.vertx.core.impl.VertxInternal;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+
+public class Throttling {
+
+  // @formatter:off
+  private enum State {
+    NEW {
+      State pending() { return PENDING; }
+      State start() { return RUNNING; }
+      State done() { throw new IllegalStateException(); }
+      State next() { throw new IllegalStateException(); }
+    },
+    PENDING {
+      State pending() { return this; }
+      State start() { return RUNNING; }
+      State done() { throw new IllegalStateException(); }
+      State next() { throw new IllegalStateException(); }
+    },
+    RUNNING {
+      State pending() { return RUNNING_PENDING; }
+      State start() { throw new IllegalStateException(); }
+      State done() { return FINISHED; }
+      State next() { throw new IllegalStateException(); }
+    },
+    RUNNING_PENDING {
+      State pending() { return this; }
+      State start() { throw new IllegalStateException(); }
+      State done() { return FINISHED_PENDING; }
+      State next() { throw new IllegalStateException(); }
+    },
+    FINISHED {
+      State pending() { return FINISHED_PENDING; }
+      State start() { throw new IllegalStateException(); }
+      State done() { throw new IllegalStateException(); }
+      State next() { return null; }
+    },
+    FINISHED_PENDING {
+      State pending() { return this; }
+      State start() { throw new IllegalStateException(); }
+      State done() { throw new IllegalStateException(); }
+      State next() { return NEW; }
+    };
+
+    abstract State pending();
+    abstract State start();
+    abstract State done();
+    abstract State next();
+  }
+  // @formatter:on
+
+  private final VertxInternal vertx;
+  private final Consumer<String> action;
+  private final ConcurrentMap<String, State> map;
+
+  public Throttling(VertxInternal vertx, Consumer<String> action) {
+    this.vertx = vertx;
+    this.action = action;
+    map = new ConcurrentHashMap<>();
+  }
+
+  public void onEvent(String address) {
+    State curr = map.compute(address, (s, state) -> state == null ? State.NEW : state.pending());
+    if (curr == State.NEW) {
+      vertx.executeBlocking(promise -> {
+        run(address);
+        promise.complete();
+      }, false);
+    }
+  }
+
+  private void run(String address) {
+    map.computeIfPresent(address, (s, state) -> state.start());
+    try {
+      action.accept(address);
+    } finally {
+      map.computeIfPresent(address, (s, state) -> state.done());
+      vertx.setTimer(20, l -> {
+        vertx.executeBlocking(promise -> {
+          checkState(address);
+          promise.complete();
+        }, false);
+      });
+    }
+  }
+
+  private void checkState(String address) {
+    State curr = map.computeIfPresent(address, (s, state) -> state.next());
+    if (curr == State.NEW) {
+      run(address);
+    }
+  }
+}

--- a/src/test/java/io/vertx/spi/cluster/ignite/impl/ThrottlingTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/impl/ThrottlingTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.spi.cluster.ignite.impl;
+
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static java.util.concurrent.TimeUnit.*;
+
+public class ThrottlingTest extends VertxTestBase {
+
+  int threadCount = 4;
+  ExecutorService executorService;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    executorService = Executors.newFixedThreadPool(threadCount);
+  }
+
+  @Test
+  public void testInterval() throws Exception {
+    int duration = 5;
+    String[] addresses = {"foo", "bar", "baz", "qux"};
+
+    ConcurrentMap<String, List<Long>> events = new ConcurrentHashMap<>(addresses.length);
+    Throttling throttling = new Throttling((VertxInternal) vertx, address -> {
+      events.compute(address, (k, v) -> {
+        if (v == null) {
+          v = Collections.synchronizedList(new LinkedList<>());
+        }
+        v.add(System.nanoTime());
+        return v;
+      });
+      sleep(1);
+    });
+
+    CountDownLatch latch = new CountDownLatch(threadCount);
+    long start = System.nanoTime();
+    for (int i = 0; i < threadCount; i++) {
+      executorService.submit(() -> {
+        try {
+          do {
+            sleepMax(5);
+            throttling.onEvent(addresses[ThreadLocalRandom.current().nextInt(addresses.length)]);
+          } while (SECONDS.convert(System.nanoTime() - start, NANOSECONDS) < duration);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+    latch.await();
+
+    assertWaitUntil(() -> {
+      if (events.size() != addresses.length) {
+        return false;
+      }
+      for (List<Long> nanoTimes : events.values()) {
+        Long previous = null;
+        for (Long nanoTime : nanoTimes) {
+          if (previous != null) {
+            if (MILLISECONDS.convert(nanoTime - previous, NANOSECONDS) < 20) {
+              return false;
+            }
+          }
+          previous = nanoTime;
+        }
+      }
+      return true;
+    }, 1000);
+  }
+
+  private void sleepMax(long time) {
+    sleep(ThreadLocalRandom.current().nextLong(time));
+  }
+
+  private void sleep(long time) {
+    try {
+      MILLISECONDS.sleep(time);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(5, SECONDS));
+    super.tearDown();
+  }
+}

--- a/src/test/java/io/vertx/spi/cluster/ignite/impl/ThrottlingTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/impl/ThrottlingTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.spi.cluster.ignite.impl;
 
+import io.vertx.core.Promise;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -52,7 +53,9 @@ public class ThrottlingTest extends VertxTestBase {
         v.add(System.nanoTime());
         return v;
       });
-      sleep(1);
+      Promise<Void> promise = Promise.promise();
+      vertx.setTimer(1, l -> promise.complete());
+      return promise.future();
     });
 
     CountDownLatch latch = new CountDownLatch(threadCount);
@@ -91,12 +94,8 @@ public class ThrottlingTest extends VertxTestBase {
   }
 
   private void sleepMax(long time) {
-    sleep(ThreadLocalRandom.current().nextLong(time));
-  }
-
-  private void sleep(long time) {
     try {
-      MILLISECONDS.sleep(time);
+      MILLISECONDS.sleep(ThreadLocalRandom.current().nextLong(time));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }


### PR DESCRIPTION
Follows-up on eclipse-vertx/vert.x#3843

The improvements mostly consist in:

* keeping local consumers data on the node
  This reduces the traffic and prevents for notifying other nodes (which are not interested anyway).

* throttling of local subscription events
  This reduces traffic and load on all nodes

Related to eclipse-vertx/vert.x#3797