### PR TITLE
Extend IgniteOptions with shutdownOnNodeStop, metrics config options and memory pagesize

### DIFF
--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteCacheOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteCacheOptionsConverter.java
@@ -76,6 +76,11 @@ public class IgniteCacheOptionsConverter {
             obj.setMaxQueryInteratorsCount(((Number)member.getValue()).intValue());
           }
           break;
+        case "metricsEnabled":
+          if (member.getValue() instanceof Boolean) {
+            obj.setMetricsEnabled((Boolean)member.getValue());
+          }
+          break;
         case "name":
           if (member.getValue() instanceof String) {
             obj.setName((String)member.getValue());
@@ -145,6 +150,7 @@ public class IgniteCacheOptionsConverter {
     json.put("invalidate", obj.isInvalidate());
     json.put("maxConcurrentAsyncOperations", obj.getMaxConcurrentAsyncOperations());
     json.put("maxQueryInteratorsCount", obj.getMaxQueryInteratorsCount());
+    json.put("metricsEnabled", obj.isMetricsEnabled());
     if (obj.getName() != null) {
       json.put("name", obj.getName());
     }

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptionsConverter.java
@@ -1,0 +1,29 @@
+package io.vertx.spi.cluster.ignite;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.spi.cluster.ignite.IgniteMetricExporterOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.spi.cluster.ignite.IgniteMetricExporterOptions} original class using Vert.x codegen.
+ */
+public class IgniteMetricExporterOptionsConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, IgniteMetricExporterOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+      }
+    }
+  }
+
+  public static void toJson(IgniteMetricExporterOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(IgniteMetricExporterOptions obj, java.util.Map<String, Object> json) {
+  }
+}

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
@@ -26,6 +26,11 @@ public class IgniteOptionsConverter {
             obj.setCacheConfiguration(list);
           }
           break;
+        case "clientFailureDetectionTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setClientFailureDetectionTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
         case "connectTimeout":
           if (member.getValue() instanceof Number) {
             obj.setConnectTimeout(((Number)member.getValue()).longValue());
@@ -44,6 +49,11 @@ public class IgniteOptionsConverter {
         case "defaultRegionMaxSize":
           if (member.getValue() instanceof Number) {
             obj.setDefaultRegionMaxSize(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "defaultRegionMetricsEnabled":
+          if (member.getValue() instanceof Boolean) {
+            obj.setDefaultRegionMetricsEnabled((Boolean)member.getValue());
           }
           break;
         case "discoverySpi":
@@ -71,14 +81,39 @@ public class IgniteOptionsConverter {
             obj.setMaxConnectTimeout(((Number)member.getValue()).longValue());
           }
           break;
+        case "metricsExpireTime":
+          if (member.getValue() instanceof Number) {
+            obj.setMetricsExpireTime(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "metricsHistorySize":
+          if (member.getValue() instanceof Number) {
+            obj.setMetricsHistorySize(((Number)member.getValue()).intValue());
+          }
+          break;
         case "metricsLogFrequency":
           if (member.getValue() instanceof Number) {
             obj.setMetricsLogFrequency(((Number)member.getValue()).longValue());
           }
           break;
+        case "metricsUpdateFrequency":
+          if (member.getValue() instanceof Number) {
+            obj.setMetricsUpdateFrequency(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "pageSize":
+          if (member.getValue() instanceof Number) {
+            obj.setPageSize(((Number)member.getValue()).intValue());
+          }
+          break;
         case "reconnectCount":
           if (member.getValue() instanceof Number) {
             obj.setReconnectCount(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "shutdownOnNodeStop":
+          if (member.getValue() instanceof Boolean) {
+            obj.setShutdownOnNodeStop((Boolean)member.getValue());
           }
           break;
         case "shutdownOnSegmentation":
@@ -89,6 +124,11 @@ public class IgniteOptionsConverter {
         case "sslContextFactory":
           if (member.getValue() instanceof JsonObject) {
             obj.setSslContextFactory(new io.vertx.spi.cluster.ignite.IgniteSslOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "systemViewExporterSpiDisabled":
+          if (member.getValue() instanceof Boolean) {
+            obj.setSystemViewExporterSpiDisabled((Boolean)member.getValue());
           }
           break;
       }
@@ -105,10 +145,12 @@ public class IgniteOptionsConverter {
       obj.getCacheConfiguration().forEach(item -> array.add(item.toJson()));
       json.put("cacheConfiguration", array);
     }
+    json.put("clientFailureDetectionTimeout", obj.getClientFailureDetectionTimeout());
     json.put("connectTimeout", obj.getConnectTimeout());
     json.put("connectionsPerNode", obj.getConnectionsPerNode());
     json.put("defaultRegionInitialSize", obj.getDefaultRegionInitialSize());
     json.put("defaultRegionMaxSize", obj.getDefaultRegionMaxSize());
+    json.put("defaultRegionMetricsEnabled", obj.isDefaultRegionMetricsEnabled());
     if (obj.getDiscoverySpi() != null) {
       json.put("discoverySpi", obj.getDiscoverySpi().toJson());
     }
@@ -118,11 +160,17 @@ public class IgniteOptionsConverter {
     }
     json.put("localPort", obj.getLocalPort());
     json.put("maxConnectTimeout", obj.getMaxConnectTimeout());
+    json.put("metricsExpireTime", obj.getMetricsExpireTime());
+    json.put("metricsHistorySize", obj.getMetricsHistorySize());
     json.put("metricsLogFrequency", obj.getMetricsLogFrequency());
+    json.put("metricsUpdateFrequency", obj.getMetricsUpdateFrequency());
+    json.put("pageSize", obj.getPageSize());
     json.put("reconnectCount", obj.getReconnectCount());
+    json.put("shutdownOnNodeStop", obj.isShutdownOnNodeStop());
     json.put("shutdownOnSegmentation", obj.isShutdownOnSegmentation());
     if (obj.getSslContextFactory() != null) {
       json.put("sslContextFactory", obj.getSslContextFactory().toJson());
     }
+    json.put("systemViewExporterSpiDisabled", obj.isSystemViewExporterSpiDisabled());
   }
 }

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
@@ -81,6 +81,11 @@ public class IgniteOptionsConverter {
             obj.setMaxConnectTimeout(((Number)member.getValue()).longValue());
           }
           break;
+        case "metricExporterSpi":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setMetricExporterSpi(new io.vertx.spi.cluster.ignite.IgniteMetricExporterOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
         case "metricsExpireTime":
           if (member.getValue() instanceof Number) {
             obj.setMetricsExpireTime(((Number)member.getValue()).longValue());
@@ -160,6 +165,9 @@ public class IgniteOptionsConverter {
     }
     json.put("localPort", obj.getLocalPort());
     json.put("maxConnectTimeout", obj.getMaxConnectTimeout());
+    if (obj.getMetricExporterSpi() != null) {
+      json.put("metricExporterSpi", obj.getMetricExporterSpi().toJson());
+    }
     json.put("metricsExpireTime", obj.getMetricsExpireTime());
     json.put("metricsHistorySize", obj.getMetricsHistorySize());
     json.put("metricsLogFrequency", obj.getMetricsLogFrequency());

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteCacheOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteCacheOptions.java
@@ -47,6 +47,7 @@ public class IgniteCacheOptions {
   private int maxQueryInteratorsCount;
   private boolean eventsDisabled;
   private JsonObject expiryPolicy;
+  private boolean metricsEnabled;
 
   /**
    * Default constructor
@@ -65,6 +66,7 @@ public class IgniteCacheOptions {
     rebalanceMode = DFLT_REBALANCE_MODE;
     maxQueryInteratorsCount = DFLT_MAX_QUERY_ITERATOR_CNT;
     eventsDisabled = DFLT_EVENTS_DISABLED;
+    metricsEnabled = false;
   }
 
   /**
@@ -93,6 +95,7 @@ public class IgniteCacheOptions {
     this.maxQueryInteratorsCount = options.maxQueryInteratorsCount;
     this.eventsDisabled = options.eventsDisabled;
     this.expiryPolicy = options.expiryPolicy;
+    this.metricsEnabled = options.metricsEnabled;
   }
 
   /**
@@ -558,6 +561,22 @@ public class IgniteCacheOptions {
    */
   public IgniteCacheOptions setExpiryPolicy(JsonObject expiryPolicy) {
     this.expiryPolicy = expiryPolicy;
+    return this;
+  }
+
+  public boolean isMetricsEnabled() {
+    return metricsEnabled;
+  }
+
+  /**
+   * Sets cache metrics enabled/disabled.
+   * Defaults to false
+   *
+   * @param metricsEnabled to set.
+   * @return reference to this, for fluency
+   */
+  public IgniteCacheOptions setMetricsEnabled(boolean metricsEnabled) {
+    this.metricsEnabled = metricsEnabled;
     return this;
   }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptions.java
@@ -15,11 +15,15 @@
  */
 package io.vertx.spi.cluster.ignite;
 
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.json.JsonObject;
 import org.apache.ignite.spi.metric.MetricExporterSpi;
 
 /**
  * @author Markus Spika
  */
+@DataObject(generateConverter = true)
 public class IgniteMetricExporterOptions {
 
   private MetricExporterSpi customSpi;
@@ -37,6 +41,17 @@ public class IgniteMetricExporterOptions {
     this.customSpi = options.customSpi;
   }
 
+  /**
+   * Constructor from JSON
+   *
+   * @param options the JSON
+   */
+  public IgniteMetricExporterOptions(JsonObject options) {
+    this();
+    IgniteMetricExporterOptionsConverter.fromJson(options, this);
+  }
+
+  @GenIgnore
   public MetricExporterSpi getCustomSpi() {
     return customSpi;
   }
@@ -47,8 +62,20 @@ public class IgniteMetricExporterOptions {
    * @param metricExporterSpi to set.
    * @return reference to this, for fluency
    */
+  @GenIgnore
   public IgniteMetricExporterOptions setCustomSpi(MetricExporterSpi metricExporterSpi) {
     this.customSpi = metricExporterSpi;
     return this;
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    IgniteMetricExporterOptionsConverter.toJson(this, json);
+    return json;
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptions.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.vertx.spi.cluster.ignite;
+
+import org.apache.ignite.spi.metric.MetricExporterSpi;
+
+/**
+ * @author Markus Spika
+ */
+public class IgniteMetricExporterOptions {
+
+  private MetricExporterSpi customSpi;
+
+  /**
+   * Default Constructor
+   */
+  public IgniteMetricExporterOptions() {
+  }
+
+  /**
+   * Copy Constructor
+   */
+  public IgniteMetricExporterOptions(final IgniteMetricExporterOptions options) {
+    this.customSpi = options.customSpi;
+  }
+
+  public MetricExporterSpi getCustomSpi() {
+    return customSpi;
+  }
+
+  /**
+   * Sets a custom MetricExporterSpi implementation.
+   *
+   * @param metricExporterSpi to set.
+   * @return reference to this, for fluency
+   */
+  public IgniteMetricExporterOptions setCustomSpi(MetricExporterSpi metricExporterSpi) {
+    this.customSpi = metricExporterSpi;
+    return this;
+  }
+}

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
@@ -18,10 +18,11 @@ package io.vertx.spi.cluster.ignite;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.apache.ignite.configuration.DataStorageConfiguration.*;
-import static org.apache.ignite.configuration.IgniteConfiguration.DFLT_METRICS_LOG_FREQ;
+import static org.apache.ignite.configuration.IgniteConfiguration.*;
 import static org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi.*;
 
 /**
@@ -41,8 +42,17 @@ public class IgniteOptions {
   private List<IgniteCacheOptions> cacheConfiguration;
   private IgniteSslOptions sslOptions;
   private boolean shutdownOnSegmentation;
+  private int pageSize;
   private long defaultRegionInitialSize;
   private long defaultRegionMaxSize;
+  private boolean defaultRegionMetricsEnabled;
+  private boolean shutdownOnNodeStop;
+  private long metricsUpdateFrequency;
+  private long clientFailureDetectionTimeout;
+  private int metricsHistorySize;
+  private long metricsExpireTime;
+  private boolean systemViewExporterSpiDisabled;
+  private IgniteMetricExporterOptions metricExporterOptions;
 
   /**
    * Default constructor
@@ -58,8 +68,17 @@ public class IgniteOptions {
     discoveryOptions = new IgniteDiscoveryOptions();
     cacheConfiguration = new ArrayList<>();
     shutdownOnSegmentation = true;
+    pageSize = DFLT_PAGE_SIZE;
     defaultRegionInitialSize = DFLT_DATA_REGION_INITIAL_SIZE;
     defaultRegionMaxSize = DFLT_DATA_REGION_MAX_SIZE;
+    defaultRegionMetricsEnabled = DFLT_METRICS_ENABLED;
+    shutdownOnNodeStop = false;
+    metricsUpdateFrequency = DFLT_METRICS_UPDATE_FREQ;
+    clientFailureDetectionTimeout = DFLT_CLIENT_FAILURE_DETECTION_TIMEOUT;
+    metricsHistorySize = DFLT_METRICS_HISTORY_SIZE;
+    metricsExpireTime = DFLT_METRICS_EXPIRE_TIME;
+    systemViewExporterSpiDisabled = false;
+    metricExporterOptions = new IgniteMetricExporterOptions();
   }
 
   /**
@@ -80,8 +99,17 @@ public class IgniteOptions {
     this.cacheConfiguration = options.cacheConfiguration;
     this.sslOptions = options.sslOptions;
     this.shutdownOnSegmentation = options.shutdownOnSegmentation;
+    this.pageSize = options.pageSize;
     this.defaultRegionInitialSize = options.defaultRegionInitialSize;
     this.defaultRegionMaxSize = options.defaultRegionMaxSize;
+    this.defaultRegionMetricsEnabled = options.defaultRegionMetricsEnabled;
+    this.shutdownOnNodeStop = options.shutdownOnNodeStop;
+    this.metricsUpdateFrequency = options.metricsUpdateFrequency;
+    this.clientFailureDetectionTimeout = options.clientFailureDetectionTimeout;
+    this.metricsHistorySize = options.metricsHistorySize;
+    this.metricsExpireTime = options.metricsExpireTime;
+    this.systemViewExporterSpiDisabled = options.systemViewExporterSpiDisabled;
+    this.metricExporterOptions = options.metricExporterOptions;
   }
 
   /**
@@ -335,6 +363,22 @@ public class IgniteOptions {
     return this;
   }
 
+  public int getPageSize() {
+    return pageSize;
+  }
+
+  /**
+   * Sets page size for all data regions.
+   * Defaults to 4096 bytes
+   *
+   * @param pageSize size in bytes.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setPageSize(int pageSize) {
+    this.pageSize = pageSize;
+    return this;
+  }
+
   /**
    * Get default data region start size.
    * Default to 256 MB
@@ -374,6 +418,133 @@ public class IgniteOptions {
    */
   public IgniteOptions setDefaultRegionMaxSize(long defaultRegionMaxSize) {
     this.defaultRegionMaxSize = defaultRegionMaxSize;
+    return this;
+  }
+
+  public boolean isDefaultRegionMetricsEnabled() {
+    return defaultRegionMetricsEnabled;
+  }
+
+  /**
+   * Sets default data region metrics enabled/disabled.
+   * Defaults to false
+   *
+   * @param defaultRegionMetricsEnabled to set.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setDefaultRegionMetricsEnabled(boolean defaultRegionMetricsEnabled) {
+    this.defaultRegionMetricsEnabled = defaultRegionMetricsEnabled;
+    return this;
+  }
+
+  public boolean isShutdownOnNodeStop() {
+    return shutdownOnNodeStop;
+  }
+
+  /**
+   * Sets that vertx will be shutdown when the node stops.
+   * Defaults to false
+   *
+   * @param shutdownOnNodeStop to set.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setShutdownOnNodeStop(boolean shutdownOnNodeStop) {
+    this.shutdownOnNodeStop = shutdownOnNodeStop;
+    return this;
+  }
+
+  public long getMetricsUpdateFrequency() {
+    return metricsUpdateFrequency;
+  }
+
+  /**
+   * Sets update frequency of metrics.
+   * Defaults to 2 seconds
+   *
+   * @param metricsUpdateFrequency in milliseconds.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setMetricsUpdateFrequency(long metricsUpdateFrequency) {
+    this.metricsUpdateFrequency = metricsUpdateFrequency;
+    return this;
+  }
+
+  public long getClientFailureDetectionTimeout() {
+    return clientFailureDetectionTimeout;
+  }
+
+  /**
+   * Sets client failure detection timeout.
+   * Defaults to 30 seconds
+   *
+   * @param clientFailureDetectionTimeout in milliseconds.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setClientFailureDetectionTimeout(long clientFailureDetectionTimeout) {
+    this.clientFailureDetectionTimeout = clientFailureDetectionTimeout;
+    return this;
+  }
+
+  public int getMetricsHistorySize() {
+    return metricsHistorySize;
+  }
+
+  /**
+   * Sets metrics history size.
+   * Defaults to 10000
+   *
+   * @param metricsHistorySize to set.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setMetricsHistorySize(int metricsHistorySize) {
+    this.metricsHistorySize = metricsHistorySize;
+    return this;
+  }
+
+  public long getMetricsExpireTime() {
+    return metricsExpireTime;
+  }
+
+  /**
+   * Sets metrics expire time.
+   * Defaults to never expire
+   *
+   * @param metricsExpireTime in milliseconds.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setMetricsExpireTime(long metricsExpireTime) {
+    this.metricsExpireTime = metricsExpireTime;
+    return this;
+  }
+
+  public boolean isSystemViewExporterSpiDisabled() {
+    return systemViewExporterSpiDisabled;
+  }
+
+  /**
+   * Sets that a NoOp Implementation of {@linkplain org.apache.ignite.spi.systemview.SystemViewExporterSpi} will be used.
+   * Defaults to false
+   *
+   * @param systemViewExporterSpiDisabled to set
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setSystemViewExporterSpiDisabled(boolean systemViewExporterSpiDisabled) {
+    this.systemViewExporterSpiDisabled = systemViewExporterSpiDisabled;
+    return this;
+  }
+
+  public IgniteMetricExporterOptions getMetricExporterSpi() {
+    return metricExporterOptions;
+  }
+
+  /**
+   * Sets fully configured instance of {@link IgniteMetricExporterOptions}.
+   *
+   * @param metricExporterOptions {@link IgniteMetricExporterOptions}.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setMetricExporterSpi(IgniteMetricExporterOptions metricExporterOptions) {
+    this.metricExporterOptions = metricExporterOptions;
     return this;
   }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/NoopSystemViewExporterSpi.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/NoopSystemViewExporterSpi.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.vertx.spi.cluster.ignite.impl;
+
+
+import org.apache.ignite.spi.IgniteSpiAdapter;
+import org.apache.ignite.spi.systemview.ReadOnlySystemViewRegistry;
+import org.apache.ignite.spi.systemview.SystemViewExporterSpi;
+import org.apache.ignite.spi.systemview.view.SystemView;
+
+import java.util.function.Predicate;
+
+/**
+ * No-Op implementation required to disable {@link org.apache.ignite.spi.systemview.jmx.JmxSystemViewExporterSpi}
+ *
+ * Ignite 2.9 initializes JMX and (if available) SQL system views IFF the array is empty
+ *
+ * {@linkplain org.apache.ignite.internal.IgnitionEx.IgniteNamedInstance#initializeDefaultSpi(org.apache.ignite.configuration.IgniteConfiguration)}
+ * <code>
+ *   F.isEmpty(cfg.getSystemViewExporterSpi())
+ * </code>
+ *
+ * @author Markus Spika
+ */
+public class NoopSystemViewExporterSpi extends IgniteSpiAdapter implements SystemViewExporterSpi {
+
+  @Override
+  public void setSystemViewRegistry(ReadOnlySystemViewRegistry registry) {
+    // no-op
+  }
+
+  @Override
+  public void setExportFilter(Predicate<SystemView<?>> filter) {
+    // no-op
+  }
+
+  @Override
+  public void spiStart(String igniteInstanceName) {
+    // no-op
+  }
+
+  @Override
+  public void spiStop() {
+    // no-op
+  }
+}

--- a/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
@@ -24,6 +24,7 @@ import org.apache.ignite.spi.discovery.DiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.apache.ignite.spi.metric.MetricExporterSpi;
 import org.apache.ignite.ssl.SslContextFactory;
 
 import javax.cache.configuration.Factory;
@@ -126,6 +127,7 @@ public class ConfigHelper {
           .setReconnectCount(options.getReconnectCount())
       )
       .setDiscoverySpi(toDiscoverySpiConfig(options.getDiscoverySpi()))
+      .setMetricExporterSpi(toMetricExporterSpi(options.getMetricExporterSpi()))
       .setCacheConfiguration(
         options.getCacheConfiguration().stream()
           .map(ConfigHelper::toCacheConfiguration)
@@ -140,10 +142,6 @@ public class ConfigHelper {
     if (options.getSslContextFactory() != null) {
       configuration.setSslContextFactory(toSslContextFactoryConfig(vertx, options.getSslContextFactory()));
     }
-
-    Optional.ofNullable(options.getMetricExporterSpi())
-      .map(IgniteMetricExporterOptions::getCustomSpi)
-      .ifPresent(configuration::setMetricExporterSpi);
 
     configuration.setDataStorageConfiguration(
       new DataStorageConfiguration()
@@ -287,6 +285,13 @@ public class ConfigHelper {
       default:
         throw new VertxException("not discovery spi found");
     }
+  }
+
+  private static MetricExporterSpi[] toMetricExporterSpi(IgniteMetricExporterOptions options) {
+    return Optional.ofNullable(options)
+      .map(IgniteMetricExporterOptions::getCustomSpi)
+      .map(spi -> new MetricExporterSpi[]{spi})
+      .orElse(new MetricExporterSpi[0]);
   }
 
   private static CacheConfiguration toCacheConfiguration(IgniteCacheOptions options) {

--- a/src/main/resources/default-ignite.json
+++ b/src/main/resources/default-ignite.json
@@ -14,7 +14,6 @@
       "writeSynchronizationMode": "FULL_SYNC"
     }
   ],
-  "includeEventTypes": ["EVT_CACHE_OBJECT_PUT", "EVT_CACHE_OBJECT_REMOVED"],
   "metricsLogFrequency": 0,
   "shutdownOnSegmentation": true
 }

--- a/src/test/java/io/vertx/spi/cluster/ignite/SystemViewExporterSpiTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/SystemViewExporterSpiTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.vertx.spi.cluster.ignite;
+
+import io.vertx.Lifecycle;
+import io.vertx.LoggingTestWatcher;
+import io.vertx.core.Vertx;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.spi.cluster.ignite.impl.NoopSystemViewExporterSpi;
+import io.vertx.test.core.VertxTestBase;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.spi.systemview.jmx.JmxSystemViewExporterSpi;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * @author Markus Spika
+ */
+public class SystemViewExporterSpiTest extends VertxTestBase {
+
+  @Rule
+  public LoggingTestWatcher watchman = new LoggingTestWatcher();
+
+  private IgniteOptions options;
+  private IgniteClusterManager clusterManager;
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    assertNotNull("options not set", options);
+    return clusterManager = new IgniteClusterManager(options);
+  }
+
+  @Override
+  protected void closeClustered(List<Vertx> clustered) throws Exception {
+    Lifecycle.closeClustered(clustered);
+  }
+
+  @Test
+  public void shouldEnableJmxSystemViewAsDefault() {
+    options = new IgniteOptions().setSystemViewExporterSpiDisabled(false);
+    startNodes(1);
+    options = null;
+
+    IgniteConfiguration cfg = clusterManager.getIgniteInstance().configuration();
+    assertNotNull(cfg);
+    assertNotNull(cfg.getSystemViewExporterSpi());
+    assertEquals(1, cfg.getSystemViewExporterSpi().length);
+    assertTrue(cfg.getSystemViewExporterSpi()[0] instanceof JmxSystemViewExporterSpi);
+
+  }
+
+  @Test
+  public void shouldDisableAllSystemViews() {
+    options = new IgniteOptions().setSystemViewExporterSpiDisabled(true);
+    startNodes(1);
+    options = null;
+
+    IgniteConfiguration cfg = clusterManager.getIgniteInstance().configuration();
+    assertNotNull(cfg);
+    assertNotNull(cfg.getSystemViewExporterSpi());
+    assertEquals(1, cfg.getSystemViewExporterSpi().length);
+    assertTrue(cfg.getSystemViewExporterSpi()[0] instanceof NoopSystemViewExporterSpi);
+  }
+}


### PR DESCRIPTION
Motivation:

* Configurable closing of VertX instance if Ignite node stops. (default false to retain previous behaviour)
* Configurable Ignite Metrics via IgniteOptions.               (defaults by Ignite to retain previous behaviour)
* Configurable enabling of Metrics via IgniteCacheOptions.     (default false to retain previous behaviour)
* Configurable disabling of Ignite JmxSystemViewExporterSpi.   (default false to retain previous behaviour)
* Custom MetricExporterSpi implementation via IgniteOptions.
* Configurable Ignite DataStorage pageSize via IgniteOptions.

Signed-off-by: Markus Spika <markus.spika@gmail.com>

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
