### PR TITLE
let ignite execute its cache futures on stripe threadpool like 2.10 did

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -442,6 +442,7 @@ public class IgniteClusterManager implements ClusterManager {
     cfg.setIgniteInstanceName(VERTX_NODE_PREFIX + uuid);
     cfg.setSegmentationPolicy(SegmentationPolicy.NOOP);
     cfg.setFailureHandler(new StopNodeFailureHandler());
+    cfg.setAsyncContinuationExecutor(Runnable::run);
     return cfg;
   }
 


### PR DESCRIPTION
Motivation:

possible solution for https://github.com/vert-x3/vertx-ignite/issues/121

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
