### PR TITLE
AsyncMapImpl fix entries() and execute() - exception handling and threading

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/AsyncMapImpl.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/AsyncMapImpl.java
@@ -18,14 +18,11 @@
 package io.vertx.spi.cluster.ignite.impl;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.shareddata.AsyncMap;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.IgniteException;
 import org.apache.ignite.cache.query.ScanQuery;
 import org.apache.ignite.lang.IgniteFuture;
 
@@ -161,19 +158,23 @@ public class AsyncMapImpl<K, V> implements AsyncMap<K, V> {
    * @param ttl Time to live in ms.
    */
   private <T> Future<T> executeWithTtl(Function<IgniteCache<K, V>, IgniteFuture<T>> cacheOp, long ttl) {
-    ContextInternal ctx = vertx.getOrCreateContext();
-    Promise<T> promise = ctx.promise();
-    IgniteCache<K, V> cache0 = ttl > 0 ?
-      cache.withExpiryPolicy(new ModifiedExpiryPolicy(new Duration(TimeUnit.MILLISECONDS, ttl))) : cache;
+    IgniteCache<K, V> cache0 = ttl > 0
+      ? cache.withExpiryPolicy(new ModifiedExpiryPolicy(new Duration(TimeUnit.MILLISECONDS, ttl)))
+      : cache;
 
-    IgniteFuture<T> future = cacheOp.apply(cache0);
-    future.listen(fut -> {
-      try {
-        promise.complete(unmarshal(future.get()));
-      } catch (IgniteException e) {
-        promise.fail(new VertxException(e));
+    return vertx.executeBlocking(
+      promise -> {
+        IgniteFuture<T> future = cacheOp.apply(cache0);
+        future.listen(
+          fut -> {
+            try {
+              promise.complete(unmarshal(future.get()));
+            } catch (final RuntimeException e) {
+              promise.fail(new VertxException(e));
+            }
+          }
+        );
       }
-    });
-    return promise.future();
+    );
   }
 }


### PR DESCRIPTION
Motivation:

* ignite may throw IgniteException or javax.cache.CacheException
* executeWithTtl() moved into executeBlocking() and signaling the result via its promise
  * IgniteCache methods (eg: getAsync() ) run on caller thread (including remote communicaton)
  * IgniteFuture#listen() calls Unsafe#park

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
