### PR TITLE
Add delay after start Option

### DIFF
--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
@@ -60,6 +60,11 @@ public class IgniteOptionsConverter {
             obj.setDefaultRegionMetricsEnabled((Boolean)member.getValue());
           }
           break;
+        case "delayAfterStart":
+          if (member.getValue() instanceof Number) {
+            obj.setDelayAfterStart(((Number)member.getValue()).longValue());
+          }
+          break;
         case "discoverySpi":
           if (member.getValue() instanceof JsonObject) {
             obj.setDiscoverySpi(new io.vertx.spi.cluster.ignite.IgniteDiscoveryOptions((io.vertx.core.json.JsonObject)member.getValue()));
@@ -155,6 +160,7 @@ public class IgniteOptionsConverter {
     json.put("defaultRegionInitialSize", obj.getDefaultRegionInitialSize());
     json.put("defaultRegionMaxSize", obj.getDefaultRegionMaxSize());
     json.put("defaultRegionMetricsEnabled", obj.isDefaultRegionMetricsEnabled());
+    json.put("delayAfterStart", obj.getDelayAfterStart());
     if (obj.getDiscoverySpi() != null) {
       json.put("discoverySpi", obj.getDiscoverySpi().toJson());
     }

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static javax.cache.expiry.Duration.ETERNAL;
 import static org.apache.ignite.events.EventType.*;
@@ -340,7 +341,12 @@ public class IgniteClusterManager implements ClusterManager {
           subsMapHelper = new SubsMapHelper(ignite, nodeSelector, vertx);
           nodeInfoMap = ignite.getOrCreateCache("__vertx.nodeInfo");
 
-          vertx.setTimer(delayAfterStart, l -> prom.complete());
+          try {
+            MILLISECONDS.sleep(delayAfterStart);
+            prom.complete();
+          } catch (InterruptedException e) {
+            prom.fail(e);
+          }
         }
       }
     }, promise);

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
@@ -52,6 +52,7 @@ public class IgniteOptions {
   private int metricsHistorySize;
   private long metricsExpireTime;
   private IgniteMetricExporterOptions metricExporterOptions;
+  private long delayAfterStart;
 
   /**
    * Default constructor
@@ -77,6 +78,7 @@ public class IgniteOptions {
     metricsHistorySize = DFLT_METRICS_HISTORY_SIZE;
     metricsExpireTime = DFLT_METRICS_EXPIRE_TIME;
     metricExporterOptions = new IgniteMetricExporterOptions();
+    delayAfterStart = 100L;
   }
 
   /**
@@ -107,6 +109,7 @@ public class IgniteOptions {
     this.metricsHistorySize = options.metricsHistorySize;
     this.metricsExpireTime = options.metricsExpireTime;
     this.metricExporterOptions = options.metricExporterOptions;
+    this.delayAfterStart = options.delayAfterStart;
   }
 
   /**
@@ -526,6 +529,22 @@ public class IgniteOptions {
    */
   public IgniteOptions setMetricExporterSpi(IgniteMetricExporterOptions metricExporterOptions) {
     this.metricExporterOptions = metricExporterOptions;
+    return this;
+  }
+
+  public long getDelayAfterStart() {
+    return delayAfterStart;
+  }
+
+  /**
+   * Sets delay in millisenconds after Ignite start.
+   * Defaults to 100ms
+   *
+   * @param delayAfterStart in milliseconds.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setDelayAfterStart(long delayAfterStart) {
+    this.delayAfterStart = delayAfterStart;
     return this;
   }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
@@ -17,7 +17,6 @@ import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgnitionEx;
 import org.apache.ignite.internal.util.typedef.F;
-import org.apache.ignite.lifecycle.LifecycleEventType;
 import org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi;
 import org.apache.ignite.spi.discovery.DiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
@@ -153,14 +152,6 @@ public class ConfigHelper {
             .setMetricsEnabled(options.isDefaultRegionMetricsEnabled())
         )
     );
-
-    if (options.isShutdownOnNodeStop()) {
-      configuration.setLifecycleBeans(
-        event -> Optional.ofNullable(event)
-          .filter(LifecycleEventType.AFTER_NODE_STOP::equals)
-          .ifPresent(ignore -> vertx.close())
-      );
-    }
 
     return configuration;
   }

--- a/src/test/java/io/vertx/core/eventbus/IgniteFaultToleranceTest.java
+++ b/src/test/java/io/vertx/core/eventbus/IgniteFaultToleranceTest.java
@@ -23,6 +23,8 @@ import io.vertx.spi.cluster.ignite.IgniteClusterManager;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 /**
  * @author Andrey Gura
  */
@@ -52,6 +54,12 @@ public class IgniteFaultToleranceTest extends FaultToleranceTest {
         "-Djava.net.preferIPv4Stack=true"
       );
     }
+  }
+
+  @Override
+  protected void afterNodeStarted(int i, Process process) throws Exception {
+    super.afterNodeStarted(i, process);
+    MILLISECONDS.sleep(500L);
   }
 
   @Override

--- a/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
@@ -47,6 +47,7 @@ public class IgniteOptionsTest {
     assertEquals(DFLT_DATA_REGION_MAX_SIZE, options.getDefaultRegionMaxSize());
     assertFalse(options.isDefaultRegionMetricsEnabled());
     assertFalse(options.isShutdownOnNodeStop());
+    assertEquals(100L, options.getDelayAfterStart());
     assertEquals(DFLT_METRICS_UPDATE_FREQ, options.getMetricsUpdateFrequency());
     assertEquals(DFLT_CLIENT_FAILURE_DETECTION_TIMEOUT.longValue(), options.getClientFailureDetectionTimeout());
     assertEquals(DFLT_METRICS_HISTORY_SIZE, options.getMetricsHistorySize());
@@ -76,6 +77,7 @@ public class IgniteOptionsTest {
     assertEquals(DFLT_DATA_REGION_MAX_SIZE, options.getDefaultRegionMaxSize());
     assertFalse(options.isDefaultRegionMetricsEnabled());
     assertFalse(options.isShutdownOnNodeStop());
+    assertEquals(100L, options.getDelayAfterStart());
     assertEquals(DFLT_METRICS_UPDATE_FREQ, options.getMetricsUpdateFrequency());
     assertEquals(DFLT_CLIENT_FAILURE_DETECTION_TIMEOUT.longValue(), options.getClientFailureDetectionTimeout());
     assertEquals(DFLT_METRICS_HISTORY_SIZE, options.getMetricsHistorySize());
@@ -182,6 +184,7 @@ public class IgniteOptionsTest {
       .setDefaultRegionMetricsEnabled(true)
       .setShutdownOnSegmentation(false)
       .setShutdownOnNodeStop(true)
+      .setDelayAfterStart(200L)
       .setMetricsUpdateFrequency(10_000L)
       .setClientFailureDetectionTimeout(15_000L)
       .setMetricsHistorySize(1)
@@ -194,23 +197,6 @@ public class IgniteOptionsTest {
     IgniteOptions options = createIgniteOptions();
     IgniteConfiguration config = ConfigHelper.toIgniteConfig(Vertx.vertx(), options);
     checkConfig(options, config);
-  }
-
-  @Test
-  public void shutdownOnNodeStop() throws InterruptedException {
-    final CountDownLatch latch = new CountDownLatch(1);
-    VertxInternal vertx = (VertxInternal) Vertx.vertx();
-    vertx.addCloseHook(promise -> {
-      latch.countDown();
-      promise.complete();
-    });
-    IgniteOptions options = new IgniteOptions().setShutdownOnNodeStop(true);
-    IgniteConfiguration config = ConfigHelper.toIgniteConfig(vertx, options);
-    assertNotNull(config.getLifecycleBeans());
-
-    config.getLifecycleBeans()[0].onLifecycleEvent(LifecycleEventType.AFTER_NODE_STOP);
-
-    assertTrue(latch.await(10, TimeUnit.SECONDS));
   }
 
   @Test(expected = VertxException.class)
@@ -232,6 +218,7 @@ public class IgniteOptionsTest {
     assertEquals(options.getMetricsLogFrequency(), json.getLong("metricsLogFrequency").longValue());
     assertEquals(options.isShutdownOnSegmentation(), json.getBoolean("shutdownOnSegmentation"));
     assertEquals(options.isShutdownOnNodeStop(), json.getBoolean("shutdownOnNodeStop"));
+    assertEquals(options.getDelayAfterStart(), json.getLong("delayAfterStart").longValue());
     assertEquals(options.getDiscoverySpi().getType(), json.getJsonObject("discoverySpi").getString("type"));
     assertEquals(options.getDiscoverySpi().getProperties().getLong("joinTimeout"), json.getJsonObject("discoverySpi").getJsonObject("properties").getLong("joinTimeout"));
     assertEquals(options.getSslContextFactory().getProtocol(), json.getJsonObject("sslContextFactory").getString("protocol"));
@@ -293,6 +280,7 @@ public class IgniteOptionsTest {
     "  \"reconnectCount\": 20,\n" +
     "  \"shutdownOnSegmentation\": true,\n" +
     "  \"shutdownOnNodeStop\": false, \n" +
+    "  \"delayAfterStart\": 100, \n" +
     "  \"discoverySpi\": {\n" +
     "    \"type\": \"TcpDiscoveryVmIpFinder\",\n" +
     "    \"properties\": {\n" +

--- a/src/test/resources/ignite.json
+++ b/src/test/resources/ignite.json
@@ -25,5 +25,6 @@
   "defaultRegionInitialSize": 20971520,
   "defaultRegionMaxSize": 41943040,
   "metricsLogFrequency": 0,
-  "shutdownOnSegmentation": false
+  "shutdownOnSegmentation": false,
+  "delayAfterStart": 200
 }


### PR DESCRIPTION
Motivation:

Add a configurable delay after the node is started, this makes sure the cluster is joined and all caches are ready.
Should make the test suite fail less.