### PR TITLE
Add evictionPolicy configuration option for on-heap caches

### DIFF
--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteCacheOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteCacheOptionsConverter.java
@@ -2,8 +2,6 @@ package io.vertx.spi.cluster.ignite;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.spi.cluster.ignite.IgniteCacheOptions}.
@@ -119,6 +117,11 @@ public class IgniteCacheOptionsConverter {
             obj.setMetricsEnabled((Boolean)member.getValue());
           }
           break;
+        case "evictionPolicy":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setEvictionPolicy(((JsonObject)member.getValue()).copy());
+          }
+          break;
       }
     }
   }
@@ -165,5 +168,8 @@ public class IgniteCacheOptionsConverter {
       json.put("expiryPolicy", obj.getExpiryPolicy());
     }
     json.put("metricsEnabled", obj.isMetricsEnabled());
+    if (obj.getEvictionPolicy() != null) {
+      json.put("evictionPolicy", obj.getEvictionPolicy());
+    }
   }
 }

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteDiscoveryOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteDiscoveryOptionsConverter.java
@@ -2,8 +2,6 @@ package io.vertx.spi.cluster.ignite;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.spi.cluster.ignite.IgniteDiscoveryOptions}.

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteMetricExporterOptionsConverter.java
@@ -2,8 +2,6 @@ package io.vertx.spi.cluster.ignite;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.spi.cluster.ignite.IgniteMetricExporterOptions}.

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
@@ -2,8 +2,6 @@ package io.vertx.spi.cluster.ignite;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.spi.cluster.ignite.IgniteOptions}.

--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteSslOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteSslOptionsConverter.java
@@ -2,8 +2,6 @@ package io.vertx.spi.cluster.ignite;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.spi.cluster.ignite.IgniteSslOptions}.

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteCacheOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteCacheOptions.java
@@ -19,6 +19,9 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 import org.apache.ignite.cache.*;
+import org.apache.ignite.cache.eviction.EvictionPolicy;
+import org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicy;
+import org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicyFactory;
 
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.*;
 import static org.apache.ignite.configuration.CacheConfiguration.*;
@@ -50,6 +53,7 @@ public class IgniteCacheOptions {
   private boolean eventsDisabled;
   private JsonObject expiryPolicy;
   private boolean metricsEnabled;
+  private JsonObject evictionPolicy;
 
   /**
    * Default constructor
@@ -69,6 +73,7 @@ public class IgniteCacheOptions {
     maxQueryInteratorsCount = DFLT_MAX_QUERY_ITERATOR_CNT;
     eventsDisabled = DFLT_EVENTS_DISABLED;
     metricsEnabled = false;
+    evictionPolicy = null;
   }
 
   /**
@@ -98,6 +103,7 @@ public class IgniteCacheOptions {
     this.eventsDisabled = options.eventsDisabled;
     this.expiryPolicy = options.expiryPolicy;
     this.metricsEnabled = options.metricsEnabled;
+    this.evictionPolicy = options.evictionPolicy;
   }
 
   /**
@@ -583,6 +589,29 @@ public class IgniteCacheOptions {
    */
   public IgniteCacheOptions setMetricsEnabled(boolean metricsEnabled) {
     this.metricsEnabled = metricsEnabled;
+    return this;
+  }
+
+  /**
+   * Gets on-heap cache eviction policy object.
+   *
+   * @return Json representation of eviction policy.
+   */
+  public JsonObject getEvictionPolicy() {
+    return evictionPolicy;
+  }
+
+  /**
+   * Sets on-heap cache eviction policy object.
+   * Requires a type which defaults to "lru" and an optional maxSize, batchSize and maxMemSize in bytes
+   * maxSize defaults to 100000, batchSize to 1 and maxMemSize to 0 (unlimited)
+   * Valid type values are: lru, fifo and sorted
+   *
+   * @param evictionPolicy Json representation of eviction policy.
+   * @return reference to this, for fluency
+   */
+  public IgniteCacheOptions setEvictionPolicy(JsonObject evictionPolicy) {
+    this.evictionPolicy = evictionPolicy;
     return this;
   }
 

--- a/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
@@ -4,6 +4,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.spi.cluster.ignite.util.ConfigHelper;
+import org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicyFactory;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi;
 import org.apache.ignite.spi.discovery.DiscoverySpi;
@@ -116,6 +117,10 @@ public class IgniteOptionsTest {
     assertEquals(options.getCacheConfiguration().get(0).isReadFromBackup(), config.getCacheConfiguration()[0].isReadFromBackup());
     assertEquals(options.getCacheConfiguration().get(0).isMetricsEnabled(), config.getCacheConfiguration()[0].isStatisticsEnabled());
     assertNotNull(config.getCacheConfiguration()[0].getExpiryPolicyFactory());
+    assertNotNull(config.getCacheConfiguration()[0].getEvictionPolicyFactory());
+    assertEquals(options.getCacheConfiguration().get(0).getEvictionPolicy().getInteger("maxSize").intValue(), ((FifoEvictionPolicyFactory)config.getCacheConfiguration()[0].getEvictionPolicyFactory()).getMaxSize());
+    assertEquals(options.getCacheConfiguration().get(0).getEvictionPolicy().getInteger("batchSize").intValue(), ((FifoEvictionPolicyFactory)config.getCacheConfiguration()[0].getEvictionPolicyFactory()).getBatchSize());
+    assertEquals(options.getCacheConfiguration().get(0).getEvictionPolicy().getInteger("maxMemSize").intValue(), ((FifoEvictionPolicyFactory)config.getCacheConfiguration()[0].getEvictionPolicyFactory()).getMaxMemorySize());
     assertEquals(options.getPageSize(), config.getDataStorageConfiguration().getPageSize());
     assertEquals(options.getDefaultRegionInitialSize(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().getInitialSize());
     assertEquals(options.getDefaultRegionMaxSize(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().getMaxSize());
@@ -173,6 +178,12 @@ public class IgniteOptionsTest {
           .put("duration", 60000L)
         )
         .setMetricsEnabled(true)
+        .setEvictionPolicy(new JsonObject()
+          .put("type", "fifo")
+          .put("maxSize", 1000)
+          .put("batchSize", 2)
+          .put("maxMemSize", 1000L)
+        )
       ))
       .setPageSize(1024)
       .setDefaultRegionInitialSize(40L * 1024 * 1024)
@@ -248,6 +259,10 @@ public class IgniteOptionsTest {
     assertEquals(options.getCacheConfiguration().get(0).getExpiryPolicy().getString("type"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("expiryPolicy").getString("type"));
     assertEquals(options.getCacheConfiguration().get(0).getExpiryPolicy().getString("duration"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("expiryPolicy").getString("duration"));
     assertEquals(options.getCacheConfiguration().get(0).isMetricsEnabled(), json.getJsonArray("cacheConfiguration").getJsonObject(0).getBoolean("metricsEnabled"));
+    assertEquals(options.getCacheConfiguration().get(0).getEvictionPolicy().getString("type"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("evictionPolicy").getString("type"));
+    assertEquals(options.getCacheConfiguration().get(0).getEvictionPolicy().getString("maxSize"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("evictionPolicy").getString("maxSize"));
+    assertEquals(options.getCacheConfiguration().get(0).getEvictionPolicy().getString("batchSize"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("evictionPolicy").getString("batchSize"));
+    assertEquals(options.getCacheConfiguration().get(0).getEvictionPolicy().getString("maxMemSize"), json.getJsonArray("cacheConfiguration").getJsonObject(0).getJsonObject("evictionPolicy").getString("maxMemSize"));
     assertEquals(options.getPageSize(), json.getInteger("pageSize").intValue());
     assertEquals(options.getDefaultRegionInitialSize(), json.getLong("defaultRegionInitialSize").longValue());
     assertEquals(options.getDefaultRegionMaxSize(), json.getLong("defaultRegionMaxSize").longValue());
@@ -308,6 +323,12 @@ public class IgniteOptionsTest {
     "    \"expiryPolicy\": {\n" +
     "      \"type\": \"created\",\n" +
     "      \"duration\": 60000\n" +
+    "    },\n" +
+    "    \"evictionPolicy\": {\n" +
+    "      \"type\": \"fifo\",\n" +
+    "      \"maxSize\": 1000,\n" +
+    "      \"batchSize\": 2,\n" +
+    "      \"maxMemSize\": 1000\n" +
     "    }\n" +
     "  }],\n" +
     "  \"sslContextFactory\": {\n" +


### PR DESCRIPTION
For on-heap caches there is the option to enable eviction based on count and memory used. The policy can be `lru`, `fifo` and `sorted` that refer to the Ignite policy classes and accept the same parameters as json properties `maxSize`, `batchSize` and `maxMemSize`