### PR TITLE
add "dataPageEvictionMode" configuration option for off-heap caches

### DIFF
--- a/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
+++ b/src/main/generated/io/vertx/spi/cluster/ignite/IgniteOptionsConverter.java
@@ -132,6 +132,11 @@ public class IgniteOptionsConverter {
             obj.setDelayAfterStart(((Number)member.getValue()).longValue());
           }
           break;
+        case "dataPageEvictionMode":
+          if (member.getValue() instanceof String) {
+            obj.setDataPageEvictionMode((String)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -176,5 +181,8 @@ public class IgniteOptionsConverter {
       json.put("metricExporterSpi", obj.getMetricExporterSpi().toJson());
     }
     json.put("delayAfterStart", obj.getDelayAfterStart());
+    if (obj.getDataPageEvictionMode() != null) {
+      json.put("dataPageEvictionMode", obj.getDataPageEvictionMode());
+    }
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteOptions.java
@@ -18,6 +18,7 @@ package io.vertx.spi.cluster.ignite;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
+import org.apache.ignite.configuration.DataPageEvictionMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +56,7 @@ public class IgniteOptions {
   private long metricsExpireTime;
   private IgniteMetricExporterOptions metricExporterOptions;
   private long delayAfterStart;
+  private DataPageEvictionMode dataPageEvictionMode;
 
   /**
    * Default constructor
@@ -81,6 +83,7 @@ public class IgniteOptions {
     metricsExpireTime = DFLT_METRICS_EXPIRE_TIME;
     metricExporterOptions = new IgniteMetricExporterOptions();
     delayAfterStart = 100L;
+    dataPageEvictionMode = DataPageEvictionMode.DISABLED;
   }
 
   /**
@@ -112,6 +115,7 @@ public class IgniteOptions {
     this.metricsExpireTime = options.metricsExpireTime;
     this.metricExporterOptions = options.metricExporterOptions;
     this.delayAfterStart = options.delayAfterStart;
+    this.dataPageEvictionMode = options.dataPageEvictionMode;
   }
 
   /**
@@ -547,6 +551,25 @@ public class IgniteOptions {
    */
   public IgniteOptions setDelayAfterStart(long delayAfterStart) {
     this.delayAfterStart = delayAfterStart;
+    return this;
+  }
+
+  /**
+   * Gets off-heap's Cache Data Page Eviction Policy.
+   *
+   * @return Data Page Cache eviction policy used in 'off-heap' Cache mode.
+   */
+  public String getDataPageEvictionMode() {
+    return dataPageEvictionMode.name();
+  }
+
+  /**
+   * Sets off-heap's Cache Data Page Eviction Policy.
+   * @param dataPageEvictionMode DataPageEvictionMode to be set.
+   * @return reference to this, for fluency
+   */
+  public IgniteOptions setDataPageEvictionMode(String dataPageEvictionMode) {
+    this.dataPageEvictionMode = DataPageEvictionMode.valueOf(dataPageEvictionMode);
     return this;
   }
 

--- a/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/util/ConfigHelper.java
@@ -15,10 +15,7 @@ import org.apache.ignite.cache.eviction.EvictionPolicy;
 import org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicyFactory;
 import org.apache.ignite.cache.eviction.lru.LruEvictionPolicyFactory;
 import org.apache.ignite.cache.eviction.sorted.SortedEvictionPolicyFactory;
-import org.apache.ignite.configuration.CacheConfiguration;
-import org.apache.ignite.configuration.DataRegionConfiguration;
-import org.apache.ignite.configuration.DataStorageConfiguration;
-import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.configuration.*;
 import org.apache.ignite.internal.IgnitionEx;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi;
@@ -155,6 +152,7 @@ public class ConfigHelper {
             .setInitialSize(options.getDefaultRegionInitialSize())
             .setMaxSize(Math.max(options.getDefaultRegionMaxSize(), options.getDefaultRegionInitialSize()))
             .setMetricsEnabled(options.isDefaultRegionMetricsEnabled())
+            .setPageEvictionMode(DataPageEvictionMode.valueOf(options.getDataPageEvictionMode()))
         )
     );
 

--- a/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
+++ b/src/test/java/io/vertx/spi/cluster/ignite/IgniteOptionsTest.java
@@ -125,6 +125,7 @@ public class IgniteOptionsTest {
     assertEquals(options.getDefaultRegionInitialSize(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().getInitialSize());
     assertEquals(options.getDefaultRegionMaxSize(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().getMaxSize());
     assertEquals(options.isDefaultRegionMetricsEnabled(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().isMetricsEnabled());
+    assertEquals(options.getDataPageEvictionMode(), config.getDataStorageConfiguration().getDefaultDataRegionConfiguration().getPageEvictionMode().name());
     assertEquals(options.getMetricsUpdateFrequency(), config.getMetricsUpdateFrequency());
     assertEquals(options.getClientFailureDetectionTimeout(), config.getClientFailureDetectionTimeout().longValue());
     assertEquals(options.getMetricsHistorySize(), config.getMetricsHistorySize());
@@ -271,6 +272,7 @@ public class IgniteOptionsTest {
     assertEquals(options.getClientFailureDetectionTimeout(), json.getLong("clientFailureDetectionTimeout").longValue());
     assertEquals(options.getMetricsHistorySize(), json.getInteger("metricsHistorySize").intValue());
     assertEquals(options.getMetricsExpireTime(), json.getLong("metricsExpireTime").longValue());
+    assertEquals(options.getDataPageEvictionMode(), json.getString("dataPageEvictionMode"));
   }
 
   @Test
@@ -350,7 +352,8 @@ public class IgniteOptionsTest {
     "  \"clientFailureDetectionTimeout\": 200000,\n" +
     "  \"metricsHistorySize\": 1,\n" +
     "  \"metricsExpireTime\": 2,\n" +
-    "  \"systemViewExporterSpiDisabled\": true\n" +
+    "  \"systemViewExporterSpiDisabled\": true,\n" +
+    "  \"dataPageEvictionMode\": \"RANDOM_2_LRU\"\n" +
     "}";
 
   @Test


### PR DESCRIPTION
Similar to recently merged https://github.com/vert-x3/vertx-ignite/pull/151, but for off-heap caches

Ignite's DataPageEvictionPolicy for off-heap lacked exposure in Vertx-Ignite config properties, but it's critical to provide the chance to override Ignite's DataPageEvictionPolicy.DISABLED default

Such default is causing nasty exception and JVM processes to hang whenever cache volume is about to exceed this Region's "maxSize" setting

Caused by: org.apache.ignite.internal.mem.IgniteOutOfMemoryException: Out of memory in data region [name=default, initSize=40.0 MiB, maxSize=40.0 MiB, persistenceEnabled=false] Try the following:
  ^-- Increase maximum off-heap memory size (DataRegionConfiguration.maxSize)
  ^-- Enable Ignite persistence (DataRegionConfiguration.persistenceEnabled)
  ^-- Enable eviction or expiration policies

Without exposing DataRegion's DataPageEvictionPolicy and given constant maxSize, the bottommost bullet point is only achievable by reducing TTL, rather then evicting gracefully with fixed TTL when the cache fills up