### PR TITLE
Prevent internal continuous query for subscriptions from failing during startup

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -54,7 +54,7 @@ public class SubsMapHelper {
     this.registrationListener = registrationListener;
     throttling = new Throttling(vertxInternal, a -> getAndUpdate(a, vertxInternal));
     shutdown = false;
-    map.query(new ContinuousQuery<IgniteRegistrationInfo, Boolean>()
+    map.withPartitionRecover().query(new ContinuousQuery<IgniteRegistrationInfo, Boolean>()
       .setAutoUnsubscribe(true)
       .setTimeInterval(100L)
       .setPageSize(128)

--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -54,11 +54,7 @@ public class SubsMapHelper {
     this.registrationListener = registrationListener;
     throttling = new Throttling(vertxInternal, a -> getAndUpdate(a, vertxInternal));
     shutdown = false;
-    map.withPartitionRecover().query(new ContinuousQuery<IgniteRegistrationInfo, Boolean>()
-      .setAutoUnsubscribe(true)
-      .setTimeInterval(100L)
-      .setPageSize(128)
-      .setLocalListener(l -> listen(l, vertxInternal)));
+    startListener(vertxInternal, 5, 500L);
   }
 
   public List<RegistrationInfo> get(String address) {
@@ -185,5 +181,26 @@ public class SubsMapHelper {
         .forEach(this::fireRegistrationUpdateEvent);
       return null;
     }, false);
+  }
+
+  private void startListener(VertxInternal vertxInternal, int maxRetries, long delay) {
+    while (maxRetries-- > 0) {
+      try {
+        map.withPartitionRecover().query(new ContinuousQuery<IgniteRegistrationInfo, Boolean>()
+          .setAutoUnsubscribe(true)
+          .setTimeInterval(100L)
+          .setPageSize(128)
+          .setLocalListener(l -> listen(l, vertxInternal)));
+        return;
+      } catch (Exception e) {
+        log.warn("Retrying to start Ignite subs map listener due to exception: " + e.getMessage());
+        try {
+          Thread.sleep(delay);
+        } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+    throw new IllegalStateException("Could not start Ignite subs map listener after retries");
   }
 }

--- a/src/main/resources/default-ignite.json
+++ b/src/main/resources/default-ignite.json
@@ -4,7 +4,8 @@
       "name": "__vertx.*",
       "cacheMode": "REPLICATED",
       "atomicityMode": "ATOMIC",
-      "writeSynchronizationMode": "FULL_SYNC"
+      "writeSynchronizationMode": "FULL_SYNC",
+      "rebalanceMode": "SYNC"
     }, {
       "name": "*",
       "cacheMode": "PARTITIONED",

--- a/src/test/resources/ignite-test.xml
+++ b/src/test/resources/ignite-test.xml
@@ -39,6 +39,7 @@
           <property name="cacheMode" value="REPLICATED"/>
           <property name="atomicityMode" value="ATOMIC"/>
           <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+          <property name="rebalanceMode" value="SYNC"/>
         </bean>
         <bean class="org.apache.ignite.configuration.CacheConfiguration">
           <property name="name" value="*"/>

--- a/src/test/resources/ignite.json
+++ b/src/test/resources/ignite.json
@@ -12,7 +12,8 @@
       "name": "__vertx.*",
       "cacheMode": "REPLICATED",
       "atomicityMode": "ATOMIC",
-      "writeSynchronizationMode": "FULL_SYNC"
+      "writeSynchronizationMode": "FULL_SYNC",
+      "rebalanceMode": "SYNC"
     }, {
       "name": "*",
       "cacheMode": "PARTITIONED",


### PR DESCRIPTION
Motivation:

stabilize startup behavior when cache state might not be ready for writing yet