### PR TITLE
Continous query cursor cleanup, localSubs clear on leave

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/impl/SubsMapHelper.java
@@ -28,6 +28,7 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.CacheEntryProcessor;
 import org.apache.ignite.cache.query.ContinuousQuery;
+import org.apache.ignite.cache.query.QueryCursor;
 import org.apache.ignite.cache.query.ScanQuery;
 
 import javax.cache.Cache;
@@ -50,6 +51,7 @@ public class SubsMapHelper {
   private final RegistrationListener registrationListener;
   private final ConcurrentMap<String, Set<RegistrationInfo>> localSubs = new ConcurrentHashMap<>();
   private final Throttling throttling;
+  private final QueryCursor<Cache.Entry<String, Set<IgniteRegistrationInfo>>> continuousQuery;
   private volatile boolean shutdown;
 
   public SubsMapHelper(Ignite ignite, RegistrationListener registrationListener, VertxInternal vertxInternal) {
@@ -57,7 +59,7 @@ public class SubsMapHelper {
     this.registrationListener = registrationListener;
     throttling = new Throttling(vertxInternal, a -> getAndUpdate(a, vertxInternal));
     shutdown = false;
-    map.query(new ContinuousQuery<String, Set<IgniteRegistrationInfo>>()
+    continuousQuery = map.query(new ContinuousQuery<String, Set<IgniteRegistrationInfo>>()
             .setAutoUnsubscribe(true)
             .setTimeInterval(100L)
             .setPageSize(128)
@@ -163,6 +165,12 @@ public class SubsMapHelper {
 
   public void leave() {
     shutdown = true;
+    try {
+      continuousQuery.close();
+    } catch (Exception e) {
+      log.debug("Failed to close continuous query cursor: " + e.getMessage());
+    }
+    localSubs.clear();
   }
 
   private void fireRegistrationUpdateEvent(String address) {
@@ -170,6 +178,9 @@ public class SubsMapHelper {
   }
 
   private Future<List<RegistrationInfo>> getAndUpdate(String address, VertxInternal vertxInternal) {
+    if (shutdown) {
+      return Future.succeededFuture();
+    }
     Promise<List<RegistrationInfo>> prom = Promise.promise();
     if (registrationListener.wantsUpdatesFor(address)) {
       prom.future().onSuccess(registrationInfos -> {
@@ -185,6 +196,9 @@ public class SubsMapHelper {
   }
 
   private void listen(final Iterable<CacheEntryEvent<? extends String, ? extends Set<IgniteRegistrationInfo>>> events, final VertxInternal vertxInternal) {
+    if (shutdown) {
+      return;
+    }
     vertxInternal.executeBlocking(() -> {
       StreamSupport.stream(events.spliterator(), false)
               .map(Cache.Entry::getKey)


### PR DESCRIPTION
Motivation:

Finally fixing a long lasting issue that was hard to spot but broke some testing and cloud lead to un-graceful shutdown behaviour in some cases.

The continuous query that handles cluster node events (e.g. join and leave) could still fire when the cluster manager is shutting down. As well the localSubs map was not cleared on leave.