### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes>

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteCacheOptions.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteCacheOptions.java
@@ -19,9 +19,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 import org.apache.ignite.cache.*;
-import org.apache.ignite.cache.eviction.EvictionPolicy;
-import org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicy;
-import org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicyFactory;
 
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.*;
 import static org.apache.ignite.configuration.CacheConfiguration.*;

--- a/src/test/java/io/vertx/servicediscovery/impl/IgniteDiscoveryImplClusteredTest.java
+++ b/src/test/java/io/vertx/servicediscovery/impl/IgniteDiscoveryImplClusteredTest.java
@@ -17,7 +17,6 @@ package io.vertx.servicediscovery.impl;
 
 import io.vertx.LoggingTestWatcher;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.servicediscovery.ServiceDiscoveryOptions;
 import io.vertx.spi.cluster.ignite.IgniteClusterManager;
 import org.junit.Before;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.